### PR TITLE
Update copySuccess & appendSuccess messages according to RFCs. https:…

### DIFF
--- a/internal/imap/uidplus/extension.go
+++ b/internal/imap/uidplus/extension.go
@@ -38,8 +38,8 @@ const Capability = "UIDPLUS"
 const (
 	copyuid      = "COPYUID"
 	appenduid    = "APPENDUID"
-	copySuccess  = "COPY successful"
-	appendSucess = "APPEND successful"
+	copySuccess  = "COPY completed"
+	appendSucess = "APPEND completed"
 )
 
 var log = logrus.WithField("pkg", "impa/uidplus") //nolint[gochecknoglobals]


### PR DESCRIPTION
Update copySuccess & appendSuccess messages according to https://github.com/ProtonMail/proton-bridge/issues/3. Variable names remain unchanged, but can be updated if desired.