### PR TITLE
Convert encoding of headers based on Content-Type charset and fix problems in "net/mail"

### DIFF
--- a/internal/imap/mailbox_message.go
+++ b/internal/imap/mailbox_message.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"io"
 	"mime/multipart"
-	"net/mail"
 	"net/textproto"
 	"regexp"
 	"sort"
@@ -39,6 +38,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	openpgperrors "golang.org/x/crypto/openpgp/errors"
+	mail "github.com/ProtonMail/proton-bridge/pkg/net/mail"
 )
 
 type doNotCacheError struct{ e error }

--- a/internal/imap/mailbox_messages.go
+++ b/internal/imap/mailbox_messages.go
@@ -20,7 +20,6 @@ package imap
 import (
 	"errors"
 	"fmt"
-	"net/mail"
 	"strings"
 	"sync"
 	"time"
@@ -31,6 +30,7 @@ import (
 	"github.com/ProtonMail/proton-bridge/pkg/pmapi"
 	"github.com/emersion/go-imap"
 	"github.com/sirupsen/logrus"
+	mail "github.com/ProtonMail/proton-bridge/pkg/net/mail"
 )
 
 // UpdateMessagesFlags alters flags for the specified message(s).

--- a/internal/imap/store.go
+++ b/internal/imap/store.go
@@ -19,12 +19,12 @@ package imap
 
 import (
 	"io"
-	"net/mail"
 
 	"github.com/ProtonMail/gopenpgp/v2/crypto"
 	"github.com/ProtonMail/proton-bridge/internal/imap/uidplus"
 	"github.com/ProtonMail/proton-bridge/internal/store"
 	"github.com/ProtonMail/proton-bridge/pkg/pmapi"
+	mail "github.com/ProtonMail/proton-bridge/pkg/net/mail"
 )
 
 type storeUserProvider interface {

--- a/internal/smtp/send_recorder_test.go
+++ b/internal/smtp/send_recorder_test.go
@@ -20,12 +20,12 @@ package smtp
 import (
 	"errors"
 	"fmt"
-	"net/mail"
 	"testing"
 	"time"
 
 	"github.com/ProtonMail/proton-bridge/pkg/pmapi"
 	"github.com/stretchr/testify/assert"
+	mail "github.com/ProtonMail/proton-bridge/pkg/net/mail"
 )
 
 type testSendRecorderGetMessageMock struct {

--- a/internal/smtp/user.go
+++ b/internal/smtp/user.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"io"
 	"mime"
-	"net/mail"
 	"regexp"
 	"strings"
 	"time"
@@ -37,6 +36,7 @@ import (
 	goSMTPBackend "github.com/emersion/go-smtp"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	mail "github.com/ProtonMail/proton-bridge/pkg/net/mail"
 )
 
 type smtpUser struct {

--- a/internal/store/event_loop_test.go
+++ b/internal/store/event_loop_test.go
@@ -18,7 +18,6 @@
 package store
 
 import (
-	"net/mail"
 	"testing"
 	"time"
 
@@ -26,6 +25,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	mail "github.com/ProtonMail/proton-bridge/pkg/net/mail"
 )
 
 func TestEventLoopProcessMoreEvents(t *testing.T) {

--- a/internal/store/mailbox_ids.go
+++ b/internal/store/mailbox_ids.go
@@ -20,13 +20,13 @@ package store
 import (
 	"bytes"
 	"math"
-	"net/mail"
 	"regexp"
 	"strings"
 
 	"github.com/ProtonMail/proton-bridge/internal/imap/uidplus"
 	"github.com/pkg/errors"
 	bolt "go.etcd.io/bbolt"
+	mail "github.com/ProtonMail/proton-bridge/pkg/net/mail"
 )
 
 // GetAPIIDsFromUIDRange returns API IDs by IMAP UID range.

--- a/internal/store/mailbox_ids_test.go
+++ b/internal/store/mailbox_ids_test.go
@@ -18,12 +18,12 @@
 package store
 
 import (
-	"net/mail"
 	"testing"
 
 	"github.com/ProtonMail/proton-bridge/pkg/pmapi"
 	a "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	mail "github.com/ProtonMail/proton-bridge/pkg/net/mail"
 )
 
 type wantID struct {

--- a/internal/store/message.go
+++ b/internal/store/message.go
@@ -18,10 +18,9 @@
 package store
 
 import (
-	"net/mail"
-
 	"github.com/ProtonMail/proton-bridge/pkg/pmapi"
 	bolt "go.etcd.io/bbolt"
+	mail "github.com/ProtonMail/proton-bridge/pkg/net/mail"
 )
 
 // Message is wrapper around `pmapi.Message` with connection to

--- a/internal/store/user_message.go
+++ b/internal/store/user_message.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"io"
 	"io/ioutil"
-	"net/mail"
 	"net/textproto"
 	"strings"
 
@@ -31,6 +30,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	bolt "go.etcd.io/bbolt"
+	mail "github.com/ProtonMail/proton-bridge/pkg/net/mail"
 )
 
 // CreateDraft creates draft with attachments.

--- a/internal/store/user_message_test.go
+++ b/internal/store/user_message_test.go
@@ -18,12 +18,12 @@
 package store
 
 import (
-	"net/mail"
 	"testing"
 
 	"github.com/ProtonMail/proton-bridge/pkg/pmapi"
 	a "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	mail "github.com/ProtonMail/proton-bridge/pkg/net/mail"
 )
 
 func TestGetAllMessageIDs(t *testing.T) {

--- a/internal/transfer/message.go
+++ b/internal/transfer/message.go
@@ -20,8 +20,9 @@ package transfer
 import (
 	"fmt"
 	"mime"
-	"net/mail"
 	"time"
+
+	mail "github.com/ProtonMail/proton-bridge/pkg/net/mail"
 )
 
 // Message is data holder passed between import and export.

--- a/internal/transfer/utils.go
+++ b/internal/transfer/utils.go
@@ -21,13 +21,13 @@ import (
 	"bufio"
 	"bytes"
 	"io/ioutil"
-	"net/mail"
 	"net/textproto"
 	"path/filepath"
 	"sort"
 	"strings"
 
 	"github.com/pkg/errors"
+	mail "github.com/ProtonMail/proton-bridge/pkg/net/mail"
 )
 
 // getFolderNames collects all folder names under `root`.

--- a/pkg/message/address.go
+++ b/pkg/message/address.go
@@ -18,10 +18,10 @@
 package message
 
 import (
-	"net/mail"
 	"strings"
 
 	"github.com/emersion/go-imap"
+	mail "github.com/ProtonMail/proton-bridge/pkg/net/mail"
 )
 
 func getAddresses(addrs []*mail.Address) (imapAddrs []*imap.Address) {

--- a/pkg/message/envelope.go
+++ b/pkg/message/envelope.go
@@ -18,11 +18,11 @@
 package message
 
 import (
-	"net/mail"
 	"time"
 
 	"github.com/ProtonMail/proton-bridge/pkg/pmapi"
 	"github.com/emersion/go-imap"
+	mail "github.com/ProtonMail/proton-bridge/pkg/net/mail"
 )
 
 func GetEnvelope(m *pmapi.Message) *imap.Envelope {

--- a/pkg/message/header.go
+++ b/pkg/message/header.go
@@ -19,7 +19,6 @@ package message
 
 import (
 	"mime"
-	"net/mail"
 	"net/textproto"
 	"regexp"
 	"strings"
@@ -27,6 +26,7 @@ import (
 
 	pmmime "github.com/ProtonMail/proton-bridge/pkg/mime"
 	"github.com/ProtonMail/proton-bridge/pkg/pmapi"
+	mail "github.com/ProtonMail/proton-bridge/pkg/net/mail"
 )
 
 // GetHeader builds the header for the message.

--- a/pkg/message/header.go
+++ b/pkg/message/header.go
@@ -20,7 +20,6 @@ package message
 import (
 	"mime"
 	"net/textproto"
-	"regexp"
 	"strings"
 	"time"
 
@@ -142,23 +141,10 @@ func GetAttachmentHeader(att *pmapi.Attachment) textproto.MIMEHeader {
 	return h
 }
 
-var reEmailComment = regexp.MustCompile("[(][^)]*[)]") // nolint[gochecknoglobals]
-
-// parseAddressComment removes the comments completely even though they should be allowed
-// http://tools.wordtothewise.com/rfc/822
-// NOTE: This should be supported in go>1.10 but it seems it's not ¯\_(ツ)_/¯
-func parseAddressComment(raw string) string {
-	return reEmailComment.ReplaceAllString(raw, "")
-}
-
 var addressParser = &mail.AddressParser{WordDecoder: pmmime.GetWordDecoder()}
 
 func parseAddressList(val string) (addrs []*mail.Address, err error) {
-	if val == "" || val == "<>" {
-		return
-	}
-
-	addrs, err = addressParser.ParseList(parseAddressComment(val))
+	addrs, err = addressParser.ParseList(val)
 	if err == nil {
 		if addrs == nil {
 			addrs = []*mail.Address{}

--- a/pkg/message/header.go
+++ b/pkg/message/header.go
@@ -156,7 +156,10 @@ func parseAddressList(val string) (addrs []*mail.Address, err error) {
 		return
 	}
 
-	addrs, err = mail.ParseAddressList(parseAddressComment(val))
+	// TODO: reuse?
+	var addressParser = &mail.AddressParser{WordDecoder: pmmime.GetWordDecoder()}
+
+	addrs, err = addressParser.ParseList(parseAddressComment(val))
 	if err == nil {
 		if addrs == nil {
 			addrs = []*mail.Address{}
@@ -182,5 +185,5 @@ func parseAddressList(val string) (addrs []*mail.Address, err error) {
 	}
 	val = strings.Join(addrList, ", ")
 
-	return mail.ParseAddressList(val)
+	return addressParser.ParseList(val)
 }

--- a/pkg/message/header.go
+++ b/pkg/message/header.go
@@ -151,13 +151,12 @@ func parseAddressComment(raw string) string {
 	return reEmailComment.ReplaceAllString(raw, "")
 }
 
+var addressParser = &mail.AddressParser{WordDecoder: pmmime.GetWordDecoder()}
+
 func parseAddressList(val string) (addrs []*mail.Address, err error) {
 	if val == "" || val == "<>" {
 		return
 	}
-
-	// TODO: reuse?
-	var addressParser = &mail.AddressParser{WordDecoder: pmmime.GetWordDecoder()}
 
 	addrs, err = addressParser.ParseList(parseAddressComment(val))
 	if err == nil {

--- a/pkg/message/parser.go
+++ b/pkg/message/parser.go
@@ -22,18 +22,17 @@ import (
 	"fmt"
 	"io"
 	"mime"
-	"net/mail"
 	"net/textproto"
 	"strings"
 
 	"github.com/ProtonMail/proton-bridge/pkg/message/parser"
 	pmmime "github.com/ProtonMail/proton-bridge/pkg/mime"
 	"github.com/ProtonMail/proton-bridge/pkg/pmapi"
-	pmail "github.com/ProtonMail/proton-bridge/pkg/net/mail"
 	"github.com/emersion/go-message"
 	"github.com/jaytaylor/html2text"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	mail "github.com/ProtonMail/proton-bridge/pkg/net/mail"
 )
 
 func Parse(r io.Reader, key, keyName string) (m *pmapi.Message, mimeBody, plainBody string, attReaders []io.Reader, err error) {
@@ -417,7 +416,7 @@ func parseMessageHeader(m *pmapi.Message, h message.Header) error { // nolint[fu
 			m.BCCList = bccList
 
 		case "date":
-			date, err := pmail.ParseDate(val)
+			date, err := mail.ParseDate(val)
 			if err != nil {
 				return errors.Wrap(err, "date")
 			}

--- a/pkg/message/parser.go
+++ b/pkg/message/parser.go
@@ -29,6 +29,7 @@ import (
 	"github.com/ProtonMail/proton-bridge/pkg/message/parser"
 	pmmime "github.com/ProtonMail/proton-bridge/pkg/mime"
 	"github.com/ProtonMail/proton-bridge/pkg/pmapi"
+	pmail "github.com/ProtonMail/proton-bridge/pkg/net/mail"
 	"github.com/emersion/go-message"
 	"github.com/jaytaylor/html2text"
 	"github.com/pkg/errors"
@@ -381,7 +382,7 @@ func parseMessageHeader(m *pmapi.Message, h message.Header) error { // nolint[fu
 		case "from":
 			sender, err := parseAddressList(val)
 			if err != nil {
-				return err
+				return errors.Wrap(err, "from")
 			}
 			if len(sender) > 0 {
 				m.Sender = sender[0]
@@ -390,35 +391,35 @@ func parseMessageHeader(m *pmapi.Message, h message.Header) error { // nolint[fu
 		case "to":
 			toList, err := parseAddressList(val)
 			if err != nil {
-				return err
+				return errors.Wrap(err, "to")
 			}
 			m.ToList = toList
 
 		case "reply-to":
 			replyTos, err := parseAddressList(val)
 			if err != nil {
-				return err
+				return errors.Wrap(err, "reply-to")
 			}
 			m.ReplyTos = replyTos
 
 		case "cc":
 			ccList, err := parseAddressList(val)
 			if err != nil {
-				return err
+				return errors.Wrap(err, "cc")
 			}
 			m.CCList = ccList
 
 		case "bcc":
 			bccList, err := parseAddressList(val)
 			if err != nil {
-				return err
+				return errors.Wrap(err, "bcc")
 			}
 			m.BCCList = bccList
 
 		case "date":
-			date, err := mail.ParseDate(val)
+			date, err := pmail.ParseDate(val)
 			if err != nil {
-				return err
+				return errors.Wrap(err, "date")
 			}
 			m.Time = date.Unix()
 		}

--- a/pkg/message/utils.go
+++ b/pkg/message/utils.go
@@ -22,10 +22,10 @@ import (
 	"html/template"
 	"io"
 	"net/http"
-	"net/mail"
 	"net/textproto"
 
 	"github.com/ProtonMail/proton-bridge/pkg/pmapi"
+	mail "github.com/ProtonMail/proton-bridge/pkg/net/mail"
 )
 
 func WriteHeader(w io.Writer, h textproto.MIMEHeader) (err error) {

--- a/pkg/mime/encoding.go
+++ b/pkg/mime/encoding.go
@@ -45,6 +45,10 @@ var wordDec = &mime.WordDecoder{
 	},
 }
 
+func GetWordDecoder() *mime.WordDecoder {
+	return wordDec;
+}
+
 // Expects trimmed lowercase.
 func getEncoding(charset string) (enc encoding.Encoding, err error) {
 	preparsed := strings.Trim(strings.ToLower(charset), " \t\r\n")

--- a/pkg/net/mail/example_test.go
+++ b/pkg/net/mail/example_test.go
@@ -1,0 +1,77 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package mail_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/mail"
+	"strings"
+)
+
+func ExampleParseAddressList() {
+	const list = "Alice <alice@example.com>, Bob <bob@example.com>, Eve <eve@example.com>"
+	emails, err := mail.ParseAddressList(list)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for _, v := range emails {
+		fmt.Println(v.Name, v.Address)
+	}
+
+	// Output:
+	// Alice alice@example.com
+	// Bob bob@example.com
+	// Eve eve@example.com
+}
+
+func ExampleParseAddress() {
+	e, err := mail.ParseAddress("Alice <alice@example.com>")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println(e.Name, e.Address)
+
+	// Output:
+	// Alice alice@example.com
+}
+
+func ExampleReadMessage() {
+	msg := `Date: Mon, 23 Jun 2015 11:40:36 -0400
+From: Gopher <from@example.com>
+To: Another Gopher <to@example.com>
+Subject: Gophers at Gophercon
+
+Message body
+`
+
+	r := strings.NewReader(msg)
+	m, err := mail.ReadMessage(r)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	header := m.Header
+	fmt.Println("Date:", header.Get("Date"))
+	fmt.Println("From:", header.Get("From"))
+	fmt.Println("To:", header.Get("To"))
+	fmt.Println("Subject:", header.Get("Subject"))
+
+	body, err := ioutil.ReadAll(m.Body)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("%s", body)
+
+	// Output:
+	// Date: Mon, 23 Jun 2015 11:40:36 -0400
+	// From: Gopher <from@example.com>
+	// To: Another Gopher <to@example.com>
+	// Subject: Gophers at Gophercon
+	// Message body
+}

--- a/pkg/net/mail/example_test.go
+++ b/pkg/net/mail/example_test.go
@@ -8,8 +8,9 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
-	"net/mail"
 	"strings"
+
+	mail "github.com/ProtonMail/proton-bridge/pkg/net/mail"
 )
 
 func ExampleParseAddressList() {

--- a/pkg/net/mail/message.go
+++ b/pkg/net/mail/message.go
@@ -1,0 +1,824 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+/*
+Package mail implements parsing of mail messages.
+
+For the most part, this package follows the syntax as specified by RFC 5322 and
+extended by RFC 6532.
+Notable divergences:
+	* Obsolete address formats are not parsed, including addresses with
+	  embedded route information.
+	* The full range of spacing (the CFWS syntax element) is not supported,
+	  such as breaking addresses across lines.
+	* No unicode normalization is performed.
+	* The special characters ()[]:;@\, are allowed to appear unquoted in names.
+*/
+package mail
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"mime"
+	"net/textproto"
+	"strings"
+	"sync"
+	"time"
+	"unicode/utf8"
+)
+
+var debug = debugT(false)
+
+type debugT bool
+
+func (d debugT) Printf(format string, args ...interface{}) {
+	if d {
+		log.Printf(format, args...)
+	}
+}
+
+// A Message represents a parsed mail message.
+type Message struct {
+	Header Header
+	Body   io.Reader
+}
+
+// ReadMessage reads a message from r.
+// The headers are parsed, and the body of the message will be available
+// for reading from msg.Body.
+func ReadMessage(r io.Reader) (msg *Message, err error) {
+	tp := textproto.NewReader(bufio.NewReader(r))
+
+	hdr, err := tp.ReadMIMEHeader()
+	if err != nil {
+		return nil, err
+	}
+
+	return &Message{
+		Header: Header(hdr),
+		Body:   tp.R,
+	}, nil
+}
+
+// Layouts suitable for passing to time.Parse.
+// These are tried in order.
+var (
+	dateLayoutsBuildOnce sync.Once
+	dateLayouts          []string
+)
+
+func buildDateLayouts() {
+	// Generate layouts based on RFC 5322, section 3.3.
+
+	dows := [...]string{"", "Mon, "}   // day-of-week
+	days := [...]string{"2", "02"}     // day = 1*2DIGIT
+	years := [...]string{"2006", "06"} // year = 4*DIGIT / 2*DIGIT
+	seconds := [...]string{":05", ""}  // second
+	// "-0700 (MST)" is not in RFC 5322, but is common.
+	zones := [...]string{"-0700", "MST"} // zone = (("+" / "-") 4DIGIT) / "GMT" / ...
+
+	for _, dow := range dows {
+		for _, day := range days {
+			for _, year := range years {
+				for _, second := range seconds {
+					for _, zone := range zones {
+						s := dow + day + " Jan " + year + " 15:04" + second + " " + zone
+						dateLayouts = append(dateLayouts, s)
+					}
+				}
+			}
+		}
+	}
+}
+
+// ParseDate parses an RFC 5322 date string.
+func ParseDate(date string) (time.Time, error) {
+	dateLayoutsBuildOnce.Do(buildDateLayouts)
+	// CR and LF must match and are tolerated anywhere in the date field.
+	date = strings.ReplaceAll(date, "\r\n", "")
+	if strings.Index(date, "\r") != -1 {
+		return time.Time{}, errors.New("mail: header has a CR without LF")
+	}
+	// Re-using some addrParser methods which support obsolete text, i.e. non-printable ASCII
+	p := addrParser{date, nil}
+	p.skipSpace()
+
+	// RFC 5322: zone = (FWS ( "+" / "-" ) 4DIGIT) / obs-zone
+	// zone length is always 5 chars unless obsolete (obs-zone)
+	if ind := strings.IndexAny(p.s, "+-"); ind != -1 && len(p.s) >= ind+5 {
+		date = p.s[:ind+5]
+		p.s = p.s[ind+5:]
+	} else if ind := strings.Index(p.s, "T"); ind != -1 && len(p.s) >= ind+1 {
+		// The last letter T of the obsolete time zone is checked when no standard time zone is found.
+		// If T is misplaced, the date to parse is garbage.
+		date = p.s[:ind+1]
+		p.s = p.s[ind+1:]
+	}
+	if !p.skipCFWS() {
+		return time.Time{}, errors.New("mail: misformatted parenthetical comment")
+	}
+	for _, layout := range dateLayouts {
+		t, err := time.Parse(layout, date)
+		if err == nil {
+			return t, nil
+		}
+	}
+	return time.Time{}, errors.New("mail: header could not be parsed")
+}
+
+// A Header represents the key-value pairs in a mail message header.
+type Header map[string][]string
+
+// Get gets the first value associated with the given key.
+// It is case insensitive; CanonicalMIMEHeaderKey is used
+// to canonicalize the provided key.
+// If there are no values associated with the key, Get returns "".
+// To access multiple values of a key, or to use non-canonical keys,
+// access the map directly.
+func (h Header) Get(key string) string {
+	return textproto.MIMEHeader(h).Get(key)
+}
+
+var ErrHeaderNotPresent = errors.New("mail: header not in message")
+
+// Date parses the Date header field.
+func (h Header) Date() (time.Time, error) {
+	hdr := h.Get("Date")
+	if hdr == "" {
+		return time.Time{}, ErrHeaderNotPresent
+	}
+	return ParseDate(hdr)
+}
+
+// AddressList parses the named header field as a list of addresses.
+func (h Header) AddressList(key string) ([]*Address, error) {
+	hdr := h.Get(key)
+	if hdr == "" {
+		return nil, ErrHeaderNotPresent
+	}
+	return ParseAddressList(hdr)
+}
+
+// Address represents a single mail address.
+// An address such as "Barry Gibbs <bg@example.com>" is represented
+// as Address{Name: "Barry Gibbs", Address: "bg@example.com"}.
+type Address struct {
+	Name    string // Proper name; may be empty.
+	Address string // user@domain
+}
+
+// ParseAddress parses a single RFC 5322 address, e.g. "Barry Gibbs <bg@example.com>"
+func ParseAddress(address string) (*Address, error) {
+	return (&addrParser{s: address}).parseSingleAddress()
+}
+
+// ParseAddressList parses the given string as a list of addresses.
+func ParseAddressList(list string) ([]*Address, error) {
+	return (&addrParser{s: list}).parseAddressList()
+}
+
+// An AddressParser is an RFC 5322 address parser.
+type AddressParser struct {
+	// WordDecoder optionally specifies a decoder for RFC 2047 encoded-words.
+	WordDecoder *mime.WordDecoder
+}
+
+// Parse parses a single RFC 5322 address of the
+// form "Gogh Fir <gf@example.com>" or "foo@example.com".
+func (p *AddressParser) Parse(address string) (*Address, error) {
+	return (&addrParser{s: address, dec: p.WordDecoder}).parseSingleAddress()
+}
+
+// ParseList parses the given string as a list of comma-separated addresses
+// of the form "Gogh Fir <gf@example.com>" or "foo@example.com".
+func (p *AddressParser) ParseList(list string) ([]*Address, error) {
+	return (&addrParser{s: list, dec: p.WordDecoder}).parseAddressList()
+}
+
+// String formats the address as a valid RFC 5322 address.
+// If the address's name contains non-ASCII characters
+// the name will be rendered according to RFC 2047.
+func (a *Address) String() string {
+	// Format address local@domain
+	at := strings.LastIndex(a.Address, "@")
+	var local, domain string
+	if at < 0 {
+		// This is a malformed address ("@" is required in addr-spec);
+		// treat the whole address as local-part.
+		local = a.Address
+	} else {
+		local, domain = a.Address[:at], a.Address[at+1:]
+	}
+
+	// Add quotes if needed
+	quoteLocal := false
+	for i, r := range local {
+		if isAtext(r, false, false) {
+			continue
+		}
+		if r == '.' {
+			// Dots are okay if they are surrounded by atext.
+			// We only need to check that the previous byte is
+			// not a dot, and this isn't the end of the string.
+			if i > 0 && local[i-1] != '.' && i < len(local)-1 {
+				continue
+			}
+		}
+		quoteLocal = true
+		break
+	}
+	if quoteLocal {
+		local = quoteString(local)
+
+	}
+
+	s := "<" + local + "@" + domain + ">"
+
+	if a.Name == "" {
+		return s
+	}
+
+	// If every character is printable ASCII, quoting is simple.
+	allPrintable := true
+	for _, r := range a.Name {
+		// isWSP here should actually be isFWS,
+		// but we don't support folding yet.
+		if !isVchar(r) && !isWSP(r) || isMultibyte(r) {
+			allPrintable = false
+			break
+		}
+	}
+	if allPrintable {
+		return quoteString(a.Name) + " " + s
+	}
+
+	// Text in an encoded-word in a display-name must not contain certain
+	// characters like quotes or parentheses (see RFC 2047 section 5.3).
+	// When this is the case encode the name using base64 encoding.
+	if strings.ContainsAny(a.Name, "\"#$%&'(),.:;<>@[]^`{|}~") {
+		return mime.BEncoding.Encode("utf-8", a.Name) + " " + s
+	}
+	return mime.QEncoding.Encode("utf-8", a.Name) + " " + s
+}
+
+type addrParser struct {
+	s   string
+	dec *mime.WordDecoder // may be nil
+}
+
+func (p *addrParser) parseAddressList() ([]*Address, error) {
+	var list []*Address
+	for {
+		p.skipSpace()
+
+		// allow skipping empty entries (RFC5322 obs-addr-list)
+		if p.consume(',') {
+			continue
+		}
+
+		addrs, err := p.parseAddress(true)
+		if err != nil {
+			return nil, err
+		}
+		list = append(list, addrs...)
+
+		if !p.skipCFWS() {
+			return nil, errors.New("mail: misformatted parenthetical comment")
+		}
+		if p.empty() {
+			break
+		}
+		if p.peek() != ',' {
+			return nil, errors.New("mail: expected comma")
+		}
+
+		// Skip empty entries for obs-addr-list.
+		for p.consume(',') {
+			p.skipSpace()
+		}
+		if p.empty() {
+			break
+		}
+	}
+	return list, nil
+}
+
+func (p *addrParser) parseSingleAddress() (*Address, error) {
+	addrs, err := p.parseAddress(true)
+	if err != nil {
+		return nil, err
+	}
+	if !p.skipCFWS() {
+		return nil, errors.New("mail: misformatted parenthetical comment")
+	}
+	if !p.empty() {
+		return nil, fmt.Errorf("mail: expected single address, got %q", p.s)
+	}
+	if len(addrs) == 0 {
+		return nil, errors.New("mail: empty group")
+	}
+	if len(addrs) > 1 {
+		return nil, errors.New("mail: group with multiple addresses")
+	}
+	return addrs[0], nil
+}
+
+// parseAddress parses a single RFC 5322 address at the start of p.
+func (p *addrParser) parseAddress(handleGroup bool) ([]*Address, error) {
+	debug.Printf("parseAddress: %q", p.s)
+	p.skipSpace()
+	if p.empty() {
+		return nil, errors.New("mail: no address")
+	}
+
+	// address = mailbox / group
+	// mailbox = name-addr / addr-spec
+	// group = display-name ":" [group-list] ";" [CFWS]
+
+	// addr-spec has a more restricted grammar than name-addr,
+	// so try parsing it first, and fallback to name-addr.
+	// TODO(dsymonds): Is this really correct?
+	spec, err := p.consumeAddrSpec()
+	if err == nil {
+		var displayName string
+		p.skipSpace()
+		if !p.empty() && p.peek() == '(' {
+			displayName, err = p.consumeDisplayNameComment()
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		return []*Address{{
+			Name:    displayName,
+			Address: spec,
+		}}, err
+	}
+	debug.Printf("parseAddress: not an addr-spec: %v", err)
+	debug.Printf("parseAddress: state is now %q", p.s)
+
+	// display-name
+	var displayName string
+	if p.peek() != '<' {
+		displayName, err = p.consumePhrase()
+		if err != nil {
+			return nil, err
+		}
+	}
+	debug.Printf("parseAddress: displayName=%q", displayName)
+
+	p.skipSpace()
+	if handleGroup {
+		if p.consume(':') {
+			return p.consumeGroupList()
+		}
+	}
+	// angle-addr = "<" addr-spec ">"
+	if !p.consume('<') {
+		atext := true
+		for _, r := range displayName {
+			if !isAtext(r, true, false) {
+				atext = false
+				break
+			}
+		}
+		if atext {
+			// The input is like "foo.bar"; it's possible the input
+			// meant to be "foo.bar@domain", or "foo.bar <...>".
+			return nil, errors.New("mail: missing '@' or angle-addr")
+		}
+		// The input is like "Full Name", which couldn't possibly be a
+		// valid email address if followed by "@domain"; the input
+		// likely meant to be "Full Name <...>".
+		return nil, errors.New("mail: no angle-addr")
+	}
+	spec, err = p.consumeAddrSpec()
+	if err != nil {
+		return nil, err
+	}
+	if !p.consume('>') {
+		return nil, errors.New("mail: unclosed angle-addr")
+	}
+	debug.Printf("parseAddress: spec=%q", spec)
+
+	return []*Address{{
+		Name:    displayName,
+		Address: spec,
+	}}, nil
+}
+
+func (p *addrParser) consumeGroupList() ([]*Address, error) {
+	var group []*Address
+	// handle empty group.
+	p.skipSpace()
+	if p.consume(';') {
+		p.skipCFWS()
+		return group, nil
+	}
+
+	for {
+		p.skipSpace()
+		// embedded groups not allowed.
+		addrs, err := p.parseAddress(false)
+		if err != nil {
+			return nil, err
+		}
+		group = append(group, addrs...)
+
+		if !p.skipCFWS() {
+			return nil, errors.New("mail: misformatted parenthetical comment")
+		}
+		if p.consume(';') {
+			p.skipCFWS()
+			break
+		}
+		if !p.consume(',') {
+			return nil, errors.New("mail: expected comma")
+		}
+	}
+	return group, nil
+}
+
+// consumeAddrSpec parses a single RFC 5322 addr-spec at the start of p.
+func (p *addrParser) consumeAddrSpec() (spec string, err error) {
+	debug.Printf("consumeAddrSpec: %q", p.s)
+
+	orig := *p
+	defer func() {
+		if err != nil {
+			*p = orig
+		}
+	}()
+
+	// local-part = dot-atom / quoted-string
+	var localPart string
+	p.skipSpace()
+	if p.empty() {
+		return "", errors.New("mail: no addr-spec")
+	}
+	if p.peek() == '"' {
+		// quoted-string
+		debug.Printf("consumeAddrSpec: parsing quoted-string")
+		localPart, err = p.consumeQuotedString()
+		if localPart == "" {
+			err = errors.New("mail: empty quoted string in addr-spec")
+		}
+	} else {
+		// dot-atom
+		debug.Printf("consumeAddrSpec: parsing dot-atom")
+		localPart, err = p.consumeAtom(true, false)
+	}
+	if err != nil {
+		debug.Printf("consumeAddrSpec: failed: %v", err)
+		return "", err
+	}
+
+	if !p.consume('@') {
+		return "", errors.New("mail: missing @ in addr-spec")
+	}
+
+	// domain = dot-atom / domain-literal
+	var domain string
+	p.skipSpace()
+	if p.empty() {
+		return "", errors.New("mail: no domain in addr-spec")
+	}
+	// TODO(dsymonds): Handle domain-literal
+	domain, err = p.consumeAtom(true, false)
+	if err != nil {
+		return "", err
+	}
+
+	return localPart + "@" + domain, nil
+}
+
+// consumePhrase parses the RFC 5322 phrase at the start of p.
+func (p *addrParser) consumePhrase() (phrase string, err error) {
+	debug.Printf("consumePhrase: [%s]", p.s)
+	// phrase = 1*word
+	var words []string
+	var isPrevEncoded bool
+	for {
+		// word = atom / quoted-string
+		var word string
+		p.skipSpace()
+		if p.empty() {
+			break
+		}
+		isEncoded := false
+		if p.peek() == '"' {
+			// quoted-string
+			word, err = p.consumeQuotedString()
+		} else {
+			// atom
+			// We actually parse dot-atom here to be more permissive
+			// than what RFC 5322 specifies.
+			word, err = p.consumeAtom(true, true)
+			if err == nil {
+				word, isEncoded, err = p.decodeRFC2047Word(word)
+			}
+		}
+
+		if err != nil {
+			break
+		}
+		debug.Printf("consumePhrase: consumed %q", word)
+		if isPrevEncoded && isEncoded {
+			words[len(words)-1] += word
+		} else {
+			words = append(words, word)
+		}
+		isPrevEncoded = isEncoded
+	}
+	// Ignore any error if we got at least one word.
+	if err != nil && len(words) == 0 {
+		debug.Printf("consumePhrase: hit err: %v", err)
+		return "", fmt.Errorf("mail: missing word in phrase: %v", err)
+	}
+	phrase = strings.Join(words, " ")
+	return phrase, nil
+}
+
+// consumeQuotedString parses the quoted string at the start of p.
+func (p *addrParser) consumeQuotedString() (qs string, err error) {
+	// Assume first byte is '"'.
+	i := 1
+	qsb := make([]rune, 0, 10)
+
+	escaped := false
+
+Loop:
+	for {
+		r, size := utf8.DecodeRuneInString(p.s[i:])
+
+		switch {
+		case size == 0:
+			return "", errors.New("mail: unclosed quoted-string")
+
+		case size == 1 && r == utf8.RuneError:
+			return "", fmt.Errorf("mail: invalid utf-8 in quoted-string: %q", p.s)
+
+		case escaped:
+			//  quoted-pair = ("\" (VCHAR / WSP))
+
+			if !isVchar(r) && !isWSP(r) {
+				return "", fmt.Errorf("mail: bad character in quoted-string: %q", r)
+			}
+
+			qsb = append(qsb, r)
+			escaped = false
+
+		case isQtext(r) || isWSP(r):
+			// qtext (printable US-ASCII excluding " and \), or
+			// FWS (almost; we're ignoring CRLF)
+			qsb = append(qsb, r)
+
+		case r == '"':
+			break Loop
+
+		case r == '\\':
+			escaped = true
+
+		default:
+			return "", fmt.Errorf("mail: bad character in quoted-string: %q", r)
+
+		}
+
+		i += size
+	}
+	p.s = p.s[i+1:]
+	return string(qsb), nil
+}
+
+// consumeAtom parses an RFC 5322 atom at the start of p.
+// If dot is true, consumeAtom parses an RFC 5322 dot-atom instead.
+// If permissive is true, consumeAtom will not fail on:
+// - leading/trailing/double dots in the atom (see golang.org/issue/4938)
+// - special characters (RFC 5322 3.2.3) except '<', '>', ':' and '"' (see golang.org/issue/21018)
+func (p *addrParser) consumeAtom(dot bool, permissive bool) (atom string, err error) {
+	i := 0
+
+Loop:
+	for {
+		r, size := utf8.DecodeRuneInString(p.s[i:])
+		switch {
+		case size == 1 && r == utf8.RuneError:
+			return "", fmt.Errorf("mail: invalid utf-8 in address: %q", p.s)
+
+		case size == 0 || !isAtext(r, dot, permissive):
+			break Loop
+
+		default:
+			i += size
+
+		}
+	}
+
+	if i == 0 {
+		return "", errors.New("mail: invalid string")
+	}
+	atom, p.s = p.s[:i], p.s[i:]
+	if !permissive {
+		if strings.HasPrefix(atom, ".") {
+			return "", errors.New("mail: leading dot in atom")
+		}
+		if strings.Contains(atom, "..") {
+			return "", errors.New("mail: double dot in atom")
+		}
+		if strings.HasSuffix(atom, ".") {
+			return "", errors.New("mail: trailing dot in atom")
+		}
+	}
+	return atom, nil
+}
+
+func (p *addrParser) consumeDisplayNameComment() (string, error) {
+	if !p.consume('(') {
+		return "", errors.New("mail: comment does not start with (")
+	}
+	comment, ok := p.consumeComment()
+	if !ok {
+		return "", errors.New("mail: misformatted parenthetical comment")
+	}
+
+	// TODO(stapelberg): parse quoted-string within comment
+	words := strings.FieldsFunc(comment, func(r rune) bool { return r == ' ' || r == '\t' })
+	for idx, word := range words {
+		decoded, isEncoded, err := p.decodeRFC2047Word(word)
+		if err != nil {
+			return "", err
+		}
+		if isEncoded {
+			words[idx] = decoded
+		}
+	}
+
+	return strings.Join(words, " "), nil
+}
+
+func (p *addrParser) consume(c byte) bool {
+	if p.empty() || p.peek() != c {
+		return false
+	}
+	p.s = p.s[1:]
+	return true
+}
+
+// skipSpace skips the leading space and tab characters.
+func (p *addrParser) skipSpace() {
+	p.s = strings.TrimLeft(p.s, " \t")
+}
+
+func (p *addrParser) peek() byte {
+	return p.s[0]
+}
+
+func (p *addrParser) empty() bool {
+	return p.len() == 0
+}
+
+func (p *addrParser) len() int {
+	return len(p.s)
+}
+
+// skipCFWS skips CFWS as defined in RFC5322.
+func (p *addrParser) skipCFWS() bool {
+	p.skipSpace()
+
+	for {
+		if !p.consume('(') {
+			break
+		}
+
+		if _, ok := p.consumeComment(); !ok {
+			return false
+		}
+
+		p.skipSpace()
+	}
+
+	return true
+}
+
+func (p *addrParser) consumeComment() (string, bool) {
+	// '(' already consumed.
+	depth := 1
+
+	var comment string
+	for {
+		if p.empty() || depth == 0 {
+			break
+		}
+
+		if p.peek() == '\\' && p.len() > 1 {
+			p.s = p.s[1:]
+		} else if p.peek() == '(' {
+			depth++
+		} else if p.peek() == ')' {
+			depth--
+		}
+		if depth > 0 {
+			comment += p.s[:1]
+		}
+		p.s = p.s[1:]
+	}
+
+	return comment, depth == 0
+}
+
+func (p *addrParser) decodeRFC2047Word(s string) (word string, isEncoded bool, err error) {
+	if p.dec != nil {
+		word, err = p.dec.Decode(s)
+	} else {
+		word, err = rfc2047Decoder.Decode(s)
+	}
+
+	if err == nil {
+		return word, true, nil
+	}
+
+	if _, ok := err.(charsetError); ok {
+		return s, true, err
+	}
+
+	// Ignore invalid RFC 2047 encoded-word errors.
+	return s, false, nil
+}
+
+var rfc2047Decoder = mime.WordDecoder{
+	CharsetReader: func(charset string, input io.Reader) (io.Reader, error) {
+		return nil, charsetError(charset)
+	},
+}
+
+type charsetError string
+
+func (e charsetError) Error() string {
+	return fmt.Sprintf("charset not supported: %q", string(e))
+}
+
+// isAtext reports whether r is an RFC 5322 atext character.
+// If dot is true, period is included.
+// If permissive is true, RFC 5322 3.2.3 specials is included,
+// except '<', '>', ':' and '"'.
+func isAtext(r rune, dot, permissive bool) bool {
+	switch r {
+	case '.':
+		return dot
+
+	// RFC 5322 3.2.3. specials
+	case '(', ')', '[', ']', ';', '@', '\\', ',':
+		return permissive
+
+	case '<', '>', '"', ':':
+		return false
+	}
+	return isVchar(r)
+}
+
+// isQtext reports whether r is an RFC 5322 qtext character.
+func isQtext(r rune) bool {
+	// Printable US-ASCII, excluding backslash or quote.
+	if r == '\\' || r == '"' {
+		return false
+	}
+	return isVchar(r)
+}
+
+// quoteString renders a string as an RFC 5322 quoted-string.
+func quoteString(s string) string {
+	var buf strings.Builder
+	buf.WriteByte('"')
+	for _, r := range s {
+		if isQtext(r) || isWSP(r) {
+			buf.WriteRune(r)
+		} else if isVchar(r) {
+			buf.WriteByte('\\')
+			buf.WriteRune(r)
+		}
+	}
+	buf.WriteByte('"')
+	return buf.String()
+}
+
+// isVchar reports whether r is an RFC 5322 VCHAR character.
+func isVchar(r rune) bool {
+	// Visible (printing) characters.
+	return '!' <= r && r <= '~' || isMultibyte(r)
+}
+
+// isMultibyte reports whether r is a multi-byte UTF-8 character
+// as supported by RFC 6532
+func isMultibyte(r rune) bool {
+	return r >= utf8.RuneSelf
+}
+
+// isWSP reports whether r is a WSP (white space).
+// WSP is a space or horizontal tab (RFC 5234 Appendix B).
+func isWSP(r rune) bool {
+	return r == ' ' || r == '\t'
+}

--- a/pkg/net/mail/message.go
+++ b/pkg/net/mail/message.go
@@ -74,18 +74,19 @@ var (
 func buildDateLayouts() {
 	// Generate layouts based on RFC 5322, section 3.3.
 
-	dows := [...]string{"", "Mon, "}   // day-of-week
+	dows := [...]string{"Mon, ", ""}   // day-of-week
 	days := [...]string{"2", "02"}     // day = 1*2DIGIT
 	years := [...]string{"2006", "06"} // year = 4*DIGIT / 2*DIGIT
 	seconds := [...]string{":05", ""}  // second
 	// "-0700 (MST)" is not in RFC 5322, but is common.
-	zones := [...]string{"-0700", "MST"} // zone = (("+" / "-") 4DIGIT) / "GMT" / ...
+	// Note: This is acutally a comment, added more relaxed timezones.
+	zones := [...]string{"-0700", "MST", "", "GMT-0700"} // zone = (("+" / "-") 4DIGIT) / "GMT" / ...
 
 	for _, dow := range dows {
-		for _, day := range days {
-			for _, year := range years {
-				for _, second := range seconds {
-					for _, zone := range zones {
+		for _, second := range seconds {
+			for _, zone := range zones {
+				for _, year := range years {
+					for _, day := range days {
 						s := dow + day + " Jan " + year + " 15:04" + second + " " + zone
 						dateLayouts = append(dateLayouts, s)
 					}
@@ -112,7 +113,7 @@ func ParseDate(date string) (time.Time, error) {
 	if ind := strings.IndexAny(p.s, "+-"); ind != -1 && len(p.s) >= ind+5 {
 		date = p.s[:ind+5]
 		p.s = p.s[ind+5:]
-	} else if ind := strings.Index(p.s, "T"); ind != -1 && len(p.s) >= ind+1 {
+	} else if ind := strings.LastIndex(p.s, "T"); ind != -1 && len(p.s) >= ind+1 {
 		// The last letter T of the obsolete time zone is checked when no standard time zone is found.
 		// If T is misplaced, the date to parse is garbage.
 		date = p.s[:ind+1]

--- a/pkg/net/mail/message.go
+++ b/pkg/net/mail/message.go
@@ -546,6 +546,11 @@ func (p *addrParser) consumePhrase() (phrase string, err error) {
 		if p.peek() == '"' {
 			// quoted-string
 			word, err = p.consumeQuotedString()
+		} else if p.len() >= 2 && p.s[:2] == "=?" {
+			word, err = p.consumeEncodedWord()
+			if err == nil {
+				word, isEncoded, err =  p.decodeRFC2047Word(word)
+			}
 		} else {
 			// atom
 			// We actually parse dot-atom here to be more permissive
@@ -625,6 +630,18 @@ Loop:
 	}
 	p.s = p.s[i+1:]
 	return string(qsb), nil
+}
+
+// consumedEncodedWord parses an encoded-word at start of p
+// It is more relaxed then an RFC 2047 allows and just searches for string bounded by '=?' and '?='.
+func (p *addrParser) consumeEncodedWord() (comment string, err error) {
+	i := strings.Index(p.s[2:], "?=")
+	if i < 0 {
+		return "", fmt.Errorf("mail: unterminated encoded word: %q", p.s)
+	}
+	comment = p.s[:i+4]
+	p.s = p.s[i+4:]
+	return comment, nil
 }
 
 // consumeAtom parses an RFC 5322 atom at the start of p.

--- a/pkg/net/mail/message_test.go
+++ b/pkg/net/mail/message_test.go
@@ -1,0 +1,1101 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package mail
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"mime"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+var parseTests = []struct {
+	in     string
+	header Header
+	body   string
+}{
+	{
+		// RFC 5322, Appendix A.1.1
+		in: `From: John Doe <jdoe@machine.example>
+To: Mary Smith <mary@example.net>
+Subject: Saying Hello
+Date: Fri, 21 Nov 1997 09:55:06 -0600
+Message-ID: <1234@local.machine.example>
+
+This is a message just to say hello.
+So, "Hello".
+`,
+		header: Header{
+			"From":       []string{"John Doe <jdoe@machine.example>"},
+			"To":         []string{"Mary Smith <mary@example.net>"},
+			"Subject":    []string{"Saying Hello"},
+			"Date":       []string{"Fri, 21 Nov 1997 09:55:06 -0600"},
+			"Message-Id": []string{"<1234@local.machine.example>"},
+		},
+		body: "This is a message just to say hello.\nSo, \"Hello\".\n",
+	},
+}
+
+func TestParsing(t *testing.T) {
+	for i, test := range parseTests {
+		msg, err := ReadMessage(bytes.NewBuffer([]byte(test.in)))
+		if err != nil {
+			t.Errorf("test #%d: Failed parsing message: %v", i, err)
+			continue
+		}
+		if !headerEq(msg.Header, test.header) {
+			t.Errorf("test #%d: Incorrectly parsed message header.\nGot:\n%+v\nWant:\n%+v",
+				i, msg.Header, test.header)
+		}
+		body, err := ioutil.ReadAll(msg.Body)
+		if err != nil {
+			t.Errorf("test #%d: Failed reading body: %v", i, err)
+			continue
+		}
+		bodyStr := string(body)
+		if bodyStr != test.body {
+			t.Errorf("test #%d: Incorrectly parsed message body.\nGot:\n%+v\nWant:\n%+v",
+				i, bodyStr, test.body)
+		}
+	}
+}
+
+func headerEq(a, b Header) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, as := range a {
+		bs, ok := b[k]
+		if !ok {
+			return false
+		}
+		if !reflect.DeepEqual(as, bs) {
+			return false
+		}
+	}
+	return true
+}
+
+func TestDateParsing(t *testing.T) {
+	tests := []struct {
+		dateStr string
+		exp     time.Time
+	}{
+		// RFC 5322, Appendix A.1.1
+		{
+			"Fri, 21 Nov 1997 09:55:06 -0600",
+			time.Date(1997, 11, 21, 9, 55, 6, 0, time.FixedZone("", -6*60*60)),
+		},
+		// RFC 5322, Appendix A.6.2
+		// Obsolete date.
+		{
+			"21 Nov 97 09:55:06 GMT",
+			time.Date(1997, 11, 21, 9, 55, 6, 0, time.FixedZone("GMT", 0)),
+		},
+		// Commonly found format not specified by RFC 5322.
+		{
+			"Fri, 21 Nov 1997 09:55:06 -0600 (MDT)",
+			time.Date(1997, 11, 21, 9, 55, 6, 0, time.FixedZone("", -6*60*60)),
+		},
+	}
+	for _, test := range tests {
+		hdr := Header{
+			"Date": []string{test.dateStr},
+		}
+		date, err := hdr.Date()
+		if err != nil {
+			t.Errorf("Header(Date: %s).Date(): %v", test.dateStr, err)
+		} else if !date.Equal(test.exp) {
+			t.Errorf("Header(Date: %s).Date() = %+v, want %+v", test.dateStr, date, test.exp)
+		}
+
+		date, err = ParseDate(test.dateStr)
+		if err != nil {
+			t.Errorf("ParseDate(%s): %v", test.dateStr, err)
+		} else if !date.Equal(test.exp) {
+			t.Errorf("ParseDate(%s) = %+v, want %+v", test.dateStr, date, test.exp)
+		}
+	}
+}
+
+func TestDateParsingCFWS(t *testing.T) {
+	tests := []struct {
+		dateStr string
+		exp     time.Time
+		valid   bool
+	}{
+		// FWS-only. No date.
+		{
+			"   ",
+			// nil is not allowed
+			time.Date(1997, 11, 21, 9, 55, 6, 0, time.FixedZone("", -6*60*60)),
+			false,
+		},
+		// FWS is allowed before optional day of week.
+		{
+			"   Fri, 21 Nov 1997 09:55:06 -0600",
+			time.Date(1997, 11, 21, 9, 55, 6, 0, time.FixedZone("", -6*60*60)),
+			true,
+		},
+		{
+			"21 Nov 1997 09:55:06 -0600",
+			time.Date(1997, 11, 21, 9, 55, 6, 0, time.FixedZone("", -6*60*60)),
+			true,
+		},
+		{
+			"Fri 21 Nov 1997 09:55:06 -0600",
+			time.Date(1997, 11, 21, 9, 55, 6, 0, time.FixedZone("", -6*60*60)),
+			false, // missing ,
+		},
+		// FWS is allowed before day of month but HTAB fails.
+		{
+			"Fri,        21 Nov 1997 09:55:06 -0600",
+			time.Date(1997, 11, 21, 9, 55, 6, 0, time.FixedZone("", -6*60*60)),
+			true,
+		},
+		// FWS is allowed before and after year but HTAB fails.
+		{
+			"Fri, 21 Nov       1997     09:55:06 -0600",
+			time.Date(1997, 11, 21, 9, 55, 6, 0, time.FixedZone("", -6*60*60)),
+			true,
+		},
+		// FWS is allowed before zone but HTAB is not handled. Obsolete timezone is handled.
+		{
+			"Fri, 21 Nov 1997 09:55:06           CST",
+			time.Time{},
+			true,
+		},
+		// FWS is allowed after date and a CRLF is already replaced.
+		{
+			"Fri, 21 Nov 1997 09:55:06           CST (no leading FWS and a trailing CRLF) \r\n",
+			time.Time{},
+			true,
+		},
+		// CFWS is a reduced set of US-ASCII where space and accentuated are obsolete. No error.
+		{
+			"Fri, 21    Nov 1997    09:55:06 -0600 (MDT and non-US-ASCII signs éèç )",
+			time.Date(1997, 11, 21, 9, 55, 6, 0, time.FixedZone("", -6*60*60)),
+			true,
+		},
+		// CFWS is allowed after zone including a nested comment.
+		// Trailing FWS is allowed.
+		{
+			"Fri, 21 Nov 1997 09:55:06 -0600    \r\n (thisisa(valid)cfws)   \t ",
+			time.Date(1997, 11, 21, 9, 55, 6, 0, time.FixedZone("", -6*60*60)),
+			true,
+		},
+		// CRLF is incomplete and misplaced.
+		{
+			"Fri, 21 Nov 1997 \r 09:55:06 -0600    \r\n (thisisa(valid)cfws)   \t ",
+			time.Date(1997, 11, 21, 9, 55, 6, 0, time.FixedZone("", -6*60*60)),
+			false,
+		},
+		// CRLF is complete but misplaced. No error is returned.
+		{
+			"Fri, 21 Nov 199\r\n7  09:55:06 -0600    \r\n (thisisa(valid)cfws)   \t ",
+			time.Date(1997, 11, 21, 9, 55, 6, 0, time.FixedZone("", -6*60*60)),
+			true, // should be false in the strict interpretation of RFC 5322.
+		},
+		// Invalid ASCII in date.
+		{
+			"Fri, 21 Nov 1997 ù 09:55:06 -0600    \r\n (thisisa(valid)cfws)   \t ",
+			time.Date(1997, 11, 21, 9, 55, 6, 0, time.FixedZone("", -6*60*60)),
+			false,
+		},
+		// CFWS chars () in date.
+		{
+			"Fri, 21 Nov () 1997 09:55:06 -0600    \r\n (thisisa(valid)cfws)   \t ",
+			time.Date(1997, 11, 21, 9, 55, 6, 0, time.FixedZone("", -6*60*60)),
+			false,
+		},
+		// Timezone is invalid but T is found in comment.
+		{
+			"Fri, 21 Nov 1997 09:55:06 -060    \r\n (Thisisa(valid)cfws)   \t ",
+			time.Date(1997, 11, 21, 9, 55, 6, 0, time.FixedZone("", -6*60*60)),
+			false,
+		},
+		// Date has no month.
+		{
+			"Fri, 21  1997 09:55:06 -0600",
+			time.Date(1997, 11, 21, 9, 55, 6, 0, time.FixedZone("", -6*60*60)),
+			false,
+		},
+		// Invalid month : OCT iso Oct
+		{
+			"Fri, 21 OCT 1997 09:55:06 CST",
+			time.Time{},
+			false,
+		},
+		// A too short time zone.
+		{
+			"Fri, 21 Nov 1997 09:55:06 -060",
+			time.Date(1997, 11, 21, 9, 55, 6, 0, time.FixedZone("", -6*60*60)),
+			false,
+		},
+		// A too short obsolete time zone.
+		{
+			"Fri, 21  1997 09:55:06 GT",
+			time.Date(1997, 11, 21, 9, 55, 6, 0, time.FixedZone("", -6*60*60)),
+			false,
+		},
+	}
+	for _, test := range tests {
+		hdr := Header{
+			"Date": []string{test.dateStr},
+		}
+		date, err := hdr.Date()
+		if err != nil && test.valid {
+			t.Errorf("Header(Date: %s).Date(): %v", test.dateStr, err)
+		} else if err == nil && test.exp.IsZero() {
+			// OK.  Used when exact result depends on the
+			// system's local zoneinfo.
+		} else if err == nil && !date.Equal(test.exp) && test.valid {
+			t.Errorf("Header(Date: %s).Date() = %+v, want %+v", test.dateStr, date, test.exp)
+		} else if err == nil && !test.valid { // an invalid expression was tested
+			t.Errorf("Header(Date: %s).Date() did not return an error but %v", test.dateStr, date)
+		}
+
+		date, err = ParseDate(test.dateStr)
+		if err != nil && test.valid {
+			t.Errorf("ParseDate(%s): %v", test.dateStr, err)
+		} else if err == nil && test.exp.IsZero() {
+			// OK.  Used when exact result depends on the
+			// system's local zoneinfo.
+		} else if err == nil && !test.valid { // an invalid expression was tested
+			t.Errorf("ParseDate(%s) did not return an error but %v", test.dateStr, date)
+		} else if err == nil && test.valid && !date.Equal(test.exp) {
+			t.Errorf("ParseDate(%s) = %+v, want %+v", test.dateStr, date, test.exp)
+		}
+	}
+}
+
+func TestAddressParsingError(t *testing.T) {
+	mustErrTestCases := [...]struct {
+		text        string
+		wantErrText string
+	}{
+		0:  {"=?iso-8859-2?Q?Bogl=E1rka_Tak=E1cs?= <unknown@gmail.com>", "charset not supported"},
+		1:  {"a@gmail.com b@gmail.com", "expected single address"},
+		2:  {string([]byte{0xed, 0xa0, 0x80}) + " <micro@example.net>", "invalid utf-8 in address"},
+		3:  {"\"" + string([]byte{0xed, 0xa0, 0x80}) + "\" <half-surrogate@example.com>", "invalid utf-8 in quoted-string"},
+		4:  {"\"\\" + string([]byte{0x80}) + "\" <escaped-invalid-unicode@example.net>", "invalid utf-8 in quoted-string"},
+		5:  {"\"\x00\" <null@example.net>", "bad character in quoted-string"},
+		6:  {"\"\\\x00\" <escaped-null@example.net>", "bad character in quoted-string"},
+		7:  {"John Doe", "no angle-addr"},
+		8:  {`<jdoe#machine.example>`, "missing @ in addr-spec"},
+		9:  {`John <middle> Doe <jdoe@machine.example>`, "missing @ in addr-spec"},
+		10: {"cfws@example.com (", "misformatted parenthetical comment"},
+		11: {"empty group: ;", "empty group"},
+		12: {"root group: embed group: null@example.com;", "no angle-addr"},
+		13: {"group not closed: null@example.com", "expected comma"},
+		14: {"group: first@example.com, second@example.com;", "group with multiple addresses"},
+		15: {"john.doe", "missing '@' or angle-addr"},
+		16: {"john.doe@", "no angle-addr"},
+		17: {"John Doe@foo.bar", "no angle-addr"},
+	}
+
+	for i, tc := range mustErrTestCases {
+		_, err := ParseAddress(tc.text)
+		if err == nil || !strings.Contains(err.Error(), tc.wantErrText) {
+			t.Errorf(`mail.ParseAddress(%q) #%d want %q, got %v`, tc.text, i, tc.wantErrText, err)
+		}
+	}
+}
+
+func TestAddressParsing(t *testing.T) {
+	tests := []struct {
+		addrsStr string
+		exp      []*Address
+	}{
+		// Bare address
+		{
+			`jdoe@machine.example`,
+			[]*Address{{
+				Address: "jdoe@machine.example",
+			}},
+		},
+		// RFC 5322, Appendix A.1.1
+		{
+			`John Doe <jdoe@machine.example>`,
+			[]*Address{{
+				Name:    "John Doe",
+				Address: "jdoe@machine.example",
+			}},
+		},
+		// RFC 5322, Appendix A.1.2
+		{
+			`"Joe Q. Public" <john.q.public@example.com>`,
+			[]*Address{{
+				Name:    "Joe Q. Public",
+				Address: "john.q.public@example.com",
+			}},
+		},
+		{
+			`"John (middle) Doe" <jdoe@machine.example>`,
+			[]*Address{{
+				Name:    "John (middle) Doe",
+				Address: "jdoe@machine.example",
+			}},
+		},
+		{
+			`John (middle) Doe <jdoe@machine.example>`,
+			[]*Address{{
+				Name:    "John (middle) Doe",
+				Address: "jdoe@machine.example",
+			}},
+		},
+		{
+			`John !@M@! Doe <jdoe@machine.example>`,
+			[]*Address{{
+				Name:    "John !@M@! Doe",
+				Address: "jdoe@machine.example",
+			}},
+		},
+		{
+			`"John <middle> Doe" <jdoe@machine.example>`,
+			[]*Address{{
+				Name:    "John <middle> Doe",
+				Address: "jdoe@machine.example",
+			}},
+		},
+		{
+			`Mary Smith <mary@x.test>, jdoe@example.org, Who? <one@y.test>`,
+			[]*Address{
+				{
+					Name:    "Mary Smith",
+					Address: "mary@x.test",
+				},
+				{
+					Address: "jdoe@example.org",
+				},
+				{
+					Name:    "Who?",
+					Address: "one@y.test",
+				},
+			},
+		},
+		{
+			`<boss@nil.test>, "Giant; \"Big\" Box" <sysservices@example.net>`,
+			[]*Address{
+				{
+					Address: "boss@nil.test",
+				},
+				{
+					Name:    `Giant; "Big" Box`,
+					Address: "sysservices@example.net",
+				},
+			},
+		},
+		// RFC 5322, Appendix A.6.1
+		{
+			`Joe Q. Public <john.q.public@example.com>`,
+			[]*Address{{
+				Name:    "Joe Q. Public",
+				Address: "john.q.public@example.com",
+			}},
+		},
+		// RFC 5322, Appendix A.1.3
+		{
+			`group1: groupaddr1@example.com;`,
+			[]*Address{
+				{
+					Name:    "",
+					Address: "groupaddr1@example.com",
+				},
+			},
+		},
+		{
+			`empty group: ;`,
+			[]*Address(nil),
+		},
+		{
+			`A Group:Ed Jones <c@a.test>,joe@where.test,John <jdoe@one.test>;`,
+			[]*Address{
+				{
+					Name:    "Ed Jones",
+					Address: "c@a.test",
+				},
+				{
+					Name:    "",
+					Address: "joe@where.test",
+				},
+				{
+					Name:    "John",
+					Address: "jdoe@one.test",
+				},
+			},
+		},
+		// RFC5322 4.4 obs-addr-list
+		{
+			` , joe@where.test,,John <jdoe@one.test>,`,
+			[]*Address{
+				{
+					Name:    "",
+					Address: "joe@where.test",
+				},
+				{
+					Name:    "John",
+					Address: "jdoe@one.test",
+				},
+			},
+		},
+		{
+			` , joe@where.test,,John <jdoe@one.test>,,`,
+			[]*Address{
+				{
+					Name:    "",
+					Address: "joe@where.test",
+				},
+				{
+					Name:    "John",
+					Address: "jdoe@one.test",
+				},
+			},
+		},
+		{
+			`Group1: <addr1@example.com>;, Group 2: addr2@example.com;, John <addr3@example.com>`,
+			[]*Address{
+				{
+					Name:    "",
+					Address: "addr1@example.com",
+				},
+				{
+					Name:    "",
+					Address: "addr2@example.com",
+				},
+				{
+					Name:    "John",
+					Address: "addr3@example.com",
+				},
+			},
+		},
+		// RFC 2047 "Q"-encoded ISO-8859-1 address.
+		{
+			`=?iso-8859-1?q?J=F6rg_Doe?= <joerg@example.com>`,
+			[]*Address{
+				{
+					Name:    `Jörg Doe`,
+					Address: "joerg@example.com",
+				},
+			},
+		},
+		// RFC 2047 "Q"-encoded US-ASCII address. Dumb but legal.
+		{
+			`=?us-ascii?q?J=6Frg_Doe?= <joerg@example.com>`,
+			[]*Address{
+				{
+					Name:    `Jorg Doe`,
+					Address: "joerg@example.com",
+				},
+			},
+		},
+		// RFC 2047 "Q"-encoded UTF-8 address.
+		{
+			`=?utf-8?q?J=C3=B6rg_Doe?= <joerg@example.com>`,
+			[]*Address{
+				{
+					Name:    `Jörg Doe`,
+					Address: "joerg@example.com",
+				},
+			},
+		},
+		// RFC 2047 "Q"-encoded UTF-8 address with multiple encoded-words.
+		{
+			`=?utf-8?q?J=C3=B6rg?=  =?utf-8?q?Doe?= <joerg@example.com>`,
+			[]*Address{
+				{
+					Name:    `JörgDoe`,
+					Address: "joerg@example.com",
+				},
+			},
+		},
+		// RFC 2047, Section 8.
+		{
+			`=?ISO-8859-1?Q?Andr=E9?= Pirard <PIRARD@vm1.ulg.ac.be>`,
+			[]*Address{
+				{
+					Name:    `André Pirard`,
+					Address: "PIRARD@vm1.ulg.ac.be",
+				},
+			},
+		},
+		// Custom example of RFC 2047 "B"-encoded ISO-8859-1 address.
+		{
+			`=?ISO-8859-1?B?SvZyZw==?= <joerg@example.com>`,
+			[]*Address{
+				{
+					Name:    `Jörg`,
+					Address: "joerg@example.com",
+				},
+			},
+		},
+		// Custom example of RFC 2047 "B"-encoded UTF-8 address.
+		{
+			`=?UTF-8?B?SsO2cmc=?= <joerg@example.com>`,
+			[]*Address{
+				{
+					Name:    `Jörg`,
+					Address: "joerg@example.com",
+				},
+			},
+		},
+		// Custom example with "." in name. For issue 4938
+		{
+			`Asem H. <noreply@example.com>`,
+			[]*Address{
+				{
+					Name:    `Asem H.`,
+					Address: "noreply@example.com",
+				},
+			},
+		},
+		// RFC 6532 3.2.3, qtext /= UTF8-non-ascii
+		{
+			`"Gø Pher" <gopher@example.com>`,
+			[]*Address{
+				{
+					Name:    `Gø Pher`,
+					Address: "gopher@example.com",
+				},
+			},
+		},
+		// RFC 6532 3.2, atext /= UTF8-non-ascii
+		{
+			`µ <micro@example.com>`,
+			[]*Address{
+				{
+					Name:    `µ`,
+					Address: "micro@example.com",
+				},
+			},
+		},
+		// RFC 6532 3.2.2, local address parts allow UTF-8
+		{
+			`Micro <µ@example.com>`,
+			[]*Address{
+				{
+					Name:    `Micro`,
+					Address: "µ@example.com",
+				},
+			},
+		},
+		// RFC 6532 3.2.4, domains parts allow UTF-8
+		{
+			`Micro <micro@µ.example.com>`,
+			[]*Address{
+				{
+					Name:    `Micro`,
+					Address: "micro@µ.example.com",
+				},
+			},
+		},
+		// Issue 14866
+		{
+			`"" <emptystring@example.com>`,
+			[]*Address{
+				{
+					Name:    "",
+					Address: "emptystring@example.com",
+				},
+			},
+		},
+		// CFWS
+		{
+			`<cfws@example.com> (CFWS (cfws))  (another comment)`,
+			[]*Address{
+				{
+					Name:    "",
+					Address: "cfws@example.com",
+				},
+			},
+		},
+		{
+			`<cfws@example.com> ()  (another comment), <cfws2@example.com> (another)`,
+			[]*Address{
+				{
+					Name:    "",
+					Address: "cfws@example.com",
+				},
+				{
+					Name:    "",
+					Address: "cfws2@example.com",
+				},
+			},
+		},
+		// Comment as display name
+		{
+			`john@example.com (John Doe)`,
+			[]*Address{
+				{
+					Name:    "John Doe",
+					Address: "john@example.com",
+				},
+			},
+		},
+		// Comment and display name
+		{
+			`John Doe <john@example.com> (Joey)`,
+			[]*Address{
+				{
+					Name:    "John Doe",
+					Address: "john@example.com",
+				},
+			},
+		},
+		// Comment as display name, no space
+		{
+			`john@example.com(John Doe)`,
+			[]*Address{
+				{
+					Name:    "John Doe",
+					Address: "john@example.com",
+				},
+			},
+		},
+		// Comment as display name, Q-encoded
+		{
+			`asjo@example.com (Adam =?utf-8?Q?Sj=C3=B8gren?=)`,
+			[]*Address{
+				{
+					Name:    "Adam Sjøgren",
+					Address: "asjo@example.com",
+				},
+			},
+		},
+		// Comment as display name, Q-encoded and tab-separated
+		{
+			`asjo@example.com (Adam	=?utf-8?Q?Sj=C3=B8gren?=)`,
+			[]*Address{
+				{
+					Name:    "Adam Sjøgren",
+					Address: "asjo@example.com",
+				},
+			},
+		},
+		// Nested comment as display name, Q-encoded
+		{
+			`asjo@example.com (Adam =?utf-8?Q?Sj=C3=B8gren?= (Debian))`,
+			[]*Address{
+				{
+					Name:    "Adam Sjøgren (Debian)",
+					Address: "asjo@example.com",
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		if len(test.exp) == 1 {
+			addr, err := ParseAddress(test.addrsStr)
+			if err != nil {
+				t.Errorf("Failed parsing (single) %q: %v", test.addrsStr, err)
+				continue
+			}
+			if !reflect.DeepEqual([]*Address{addr}, test.exp) {
+				t.Errorf("Parse (single) of %q: got %+v, want %+v", test.addrsStr, addr, test.exp)
+			}
+		}
+
+		addrs, err := ParseAddressList(test.addrsStr)
+		if err != nil {
+			t.Errorf("Failed parsing (list) %q: %v", test.addrsStr, err)
+			continue
+		}
+		if !reflect.DeepEqual(addrs, test.exp) {
+			t.Errorf("Parse (list) of %q: got %+v, want %+v", test.addrsStr, addrs, test.exp)
+		}
+	}
+}
+
+func TestAddressParser(t *testing.T) {
+	tests := []struct {
+		addrsStr string
+		exp      []*Address
+	}{
+		// Bare address
+		{
+			`jdoe@machine.example`,
+			[]*Address{{
+				Address: "jdoe@machine.example",
+			}},
+		},
+		// RFC 5322, Appendix A.1.1
+		{
+			`John Doe <jdoe@machine.example>`,
+			[]*Address{{
+				Name:    "John Doe",
+				Address: "jdoe@machine.example",
+			}},
+		},
+		// RFC 5322, Appendix A.1.2
+		{
+			`"Joe Q. Public" <john.q.public@example.com>`,
+			[]*Address{{
+				Name:    "Joe Q. Public",
+				Address: "john.q.public@example.com",
+			}},
+		},
+		{
+			`Mary Smith <mary@x.test>, jdoe@example.org, Who? <one@y.test>`,
+			[]*Address{
+				{
+					Name:    "Mary Smith",
+					Address: "mary@x.test",
+				},
+				{
+					Address: "jdoe@example.org",
+				},
+				{
+					Name:    "Who?",
+					Address: "one@y.test",
+				},
+			},
+		},
+		{
+			`<boss@nil.test>, "Giant; \"Big\" Box" <sysservices@example.net>`,
+			[]*Address{
+				{
+					Address: "boss@nil.test",
+				},
+				{
+					Name:    `Giant; "Big" Box`,
+					Address: "sysservices@example.net",
+				},
+			},
+		},
+		// RFC 2047 "Q"-encoded ISO-8859-1 address.
+		{
+			`=?iso-8859-1?q?J=F6rg_Doe?= <joerg@example.com>`,
+			[]*Address{
+				{
+					Name:    `Jörg Doe`,
+					Address: "joerg@example.com",
+				},
+			},
+		},
+		// RFC 2047 "Q"-encoded US-ASCII address. Dumb but legal.
+		{
+			`=?us-ascii?q?J=6Frg_Doe?= <joerg@example.com>`,
+			[]*Address{
+				{
+					Name:    `Jorg Doe`,
+					Address: "joerg@example.com",
+				},
+			},
+		},
+		// RFC 2047 "Q"-encoded ISO-8859-15 address.
+		{
+			`=?ISO-8859-15?Q?J=F6rg_Doe?= <joerg@example.com>`,
+			[]*Address{
+				{
+					Name:    `Jörg Doe`,
+					Address: "joerg@example.com",
+				},
+			},
+		},
+		// RFC 2047 "B"-encoded windows-1252 address.
+		{
+			`=?windows-1252?q?Andr=E9?= Pirard <PIRARD@vm1.ulg.ac.be>`,
+			[]*Address{
+				{
+					Name:    `André Pirard`,
+					Address: "PIRARD@vm1.ulg.ac.be",
+				},
+			},
+		},
+		// Custom example of RFC 2047 "B"-encoded ISO-8859-15 address.
+		{
+			`=?ISO-8859-15?B?SvZyZw==?= <joerg@example.com>`,
+			[]*Address{
+				{
+					Name:    `Jörg`,
+					Address: "joerg@example.com",
+				},
+			},
+		},
+		// Custom example of RFC 2047 "B"-encoded UTF-8 address.
+		{
+			`=?UTF-8?B?SsO2cmc=?= <joerg@example.com>`,
+			[]*Address{
+				{
+					Name:    `Jörg`,
+					Address: "joerg@example.com",
+				},
+			},
+		},
+		// Custom example with "." in name. For issue 4938
+		{
+			`Asem H. <noreply@example.com>`,
+			[]*Address{
+				{
+					Name:    `Asem H.`,
+					Address: "noreply@example.com",
+				},
+			},
+		},
+	}
+
+	ap := AddressParser{WordDecoder: &mime.WordDecoder{
+		CharsetReader: func(charset string, input io.Reader) (io.Reader, error) {
+			in, err := ioutil.ReadAll(input)
+			if err != nil {
+				return nil, err
+			}
+
+			switch charset {
+			case "iso-8859-15":
+				in = bytes.ReplaceAll(in, []byte("\xf6"), []byte("ö"))
+			case "windows-1252":
+				in = bytes.ReplaceAll(in, []byte("\xe9"), []byte("é"))
+			}
+
+			return bytes.NewReader(in), nil
+		},
+	}}
+
+	for _, test := range tests {
+		if len(test.exp) == 1 {
+			addr, err := ap.Parse(test.addrsStr)
+			if err != nil {
+				t.Errorf("Failed parsing (single) %q: %v", test.addrsStr, err)
+				continue
+			}
+			if !reflect.DeepEqual([]*Address{addr}, test.exp) {
+				t.Errorf("Parse (single) of %q: got %+v, want %+v", test.addrsStr, addr, test.exp)
+			}
+		}
+
+		addrs, err := ap.ParseList(test.addrsStr)
+		if err != nil {
+			t.Errorf("Failed parsing (list) %q: %v", test.addrsStr, err)
+			continue
+		}
+		if !reflect.DeepEqual(addrs, test.exp) {
+			t.Errorf("Parse (list) of %q: got %+v, want %+v", test.addrsStr, addrs, test.exp)
+		}
+	}
+}
+
+func TestAddressString(t *testing.T) {
+	tests := []struct {
+		addr *Address
+		exp  string
+	}{
+		{
+			&Address{Address: "bob@example.com"},
+			"<bob@example.com>",
+		},
+		{ // quoted local parts: RFC 5322, 3.4.1. and 3.2.4.
+			&Address{Address: `my@idiot@address@example.com`},
+			`<"my@idiot@address"@example.com>`,
+		},
+		{ // quoted local parts
+			&Address{Address: ` @example.com`},
+			`<" "@example.com>`,
+		},
+		{
+			&Address{Name: "Bob", Address: "bob@example.com"},
+			`"Bob" <bob@example.com>`,
+		},
+		{
+			// note the ö (o with an umlaut)
+			&Address{Name: "Böb", Address: "bob@example.com"},
+			`=?utf-8?q?B=C3=B6b?= <bob@example.com>`,
+		},
+		{
+			&Address{Name: "Bob Jane", Address: "bob@example.com"},
+			`"Bob Jane" <bob@example.com>`,
+		},
+		{
+			&Address{Name: "Böb Jacöb", Address: "bob@example.com"},
+			`=?utf-8?q?B=C3=B6b_Jac=C3=B6b?= <bob@example.com>`,
+		},
+		{ // https://golang.org/issue/12098
+			&Address{Name: "Rob", Address: ""},
+			`"Rob" <@>`,
+		},
+		{ // https://golang.org/issue/12098
+			&Address{Name: "Rob", Address: "@"},
+			`"Rob" <@>`,
+		},
+		{
+			&Address{Name: "Böb, Jacöb", Address: "bob@example.com"},
+			`=?utf-8?b?QsO2YiwgSmFjw7Zi?= <bob@example.com>`,
+		},
+		{
+			&Address{Name: "=??Q?x?=", Address: "hello@world.com"},
+			`"=??Q?x?=" <hello@world.com>`,
+		},
+		{
+			&Address{Name: "=?hello", Address: "hello@world.com"},
+			`"=?hello" <hello@world.com>`,
+		},
+		{
+			&Address{Name: "world?=", Address: "hello@world.com"},
+			`"world?=" <hello@world.com>`,
+		},
+		{
+			// should q-encode even for invalid utf-8.
+			&Address{Name: string([]byte{0xed, 0xa0, 0x80}), Address: "invalid-utf8@example.net"},
+			"=?utf-8?q?=ED=A0=80?= <invalid-utf8@example.net>",
+		},
+	}
+	for _, test := range tests {
+		s := test.addr.String()
+		if s != test.exp {
+			t.Errorf("Address%+v.String() = %v, want %v", *test.addr, s, test.exp)
+			continue
+		}
+
+		// Check round-trip.
+		if test.addr.Address != "" && test.addr.Address != "@" {
+			a, err := ParseAddress(test.exp)
+			if err != nil {
+				t.Errorf("ParseAddress(%#q): %v", test.exp, err)
+				continue
+			}
+			if a.Name != test.addr.Name || a.Address != test.addr.Address {
+				t.Errorf("ParseAddress(%#q) = %#v, want %#v", test.exp, a, test.addr)
+			}
+		}
+	}
+}
+
+// Check if all valid addresses can be parsed, formatted and parsed again
+func TestAddressParsingAndFormatting(t *testing.T) {
+
+	// Should pass
+	tests := []string{
+		`<Bob@example.com>`,
+		`<bob.bob@example.com>`,
+		`<".bob"@example.com>`,
+		`<" "@example.com>`,
+		`<some.mail-with-dash@example.com>`,
+		`<"dot.and space"@example.com>`,
+		`<"very.unusual.@.unusual.com"@example.com>`,
+		`<admin@mailserver1>`,
+		`<postmaster@localhost>`,
+		"<#!$%&'*+-/=?^_`{}|~@example.org>",
+		`<"very.(),:;<>[]\".VERY.\"very@\\ \"very\".unusual"@strange.example.com>`, // escaped quotes
+		`<"()<>[]:,;@\\\"!#$%&'*+-/=?^_{}| ~.a"@example.org>`,                      // escaped backslashes
+		`<"Abc\\@def"@example.com>`,
+		`<"Joe\\Blow"@example.com>`,
+		`<test1/test2=test3@example.com>`,
+		`<def!xyz%abc@example.com>`,
+		`<_somename@example.com>`,
+		`<joe@uk>`,
+		`<~@example.com>`,
+		`<"..."@test.com>`,
+		`<"john..doe"@example.com>`,
+		`<"john.doe."@example.com>`,
+		`<".john.doe"@example.com>`,
+		`<"."@example.com>`,
+		`<".."@example.com>`,
+		`<"0:"@0>`,
+	}
+
+	for _, test := range tests {
+		addr, err := ParseAddress(test)
+		if err != nil {
+			t.Errorf("Couldn't parse address %s: %s", test, err.Error())
+			continue
+		}
+		str := addr.String()
+		addr, err = ParseAddress(str)
+		if err != nil {
+			t.Errorf("ParseAddr(%q) error: %v", test, err)
+			continue
+		}
+
+		if addr.String() != test {
+			t.Errorf("String() round-trip = %q; want %q", addr, test)
+			continue
+		}
+
+	}
+
+	// Should fail
+	badTests := []string{
+		`<Abc.example.com>`,
+		`<A@b@c@example.com>`,
+		`<a"b(c)d,e:f;g<h>i[j\k]l@example.com>`,
+		`<just"not"right@example.com>`,
+		`<this is"not\allowed@example.com>`,
+		`<this\ still\"not\\allowed@example.com>`,
+		`<john..doe@example.com>`,
+		`<john.doe@example..com>`,
+		`<john.doe@example..com>`,
+		`<john.doe.@example.com>`,
+		`<john.doe.@.example.com>`,
+		`<.john.doe@example.com>`,
+		`<@example.com>`,
+		`<.@example.com>`,
+		`<test@.>`,
+		`< @example.com>`,
+		`<""test""blah""@example.com>`,
+		`<""@0>`,
+	}
+
+	for _, test := range badTests {
+		_, err := ParseAddress(test)
+		if err == nil {
+			t.Errorf("Should have failed to parse address: %s", test)
+			continue
+		}
+
+	}
+
+}
+
+func TestAddressFormattingAndParsing(t *testing.T) {
+	tests := []*Address{
+		{Name: "@lïce", Address: "alice@example.com"},
+		{Name: "Böb O'Connor", Address: "bob@example.com"},
+		{Name: "???", Address: "bob@example.com"},
+		{Name: "Böb ???", Address: "bob@example.com"},
+		{Name: "Böb (Jacöb)", Address: "bob@example.com"},
+		{Name: "à#$%&'(),.:;<>@[]^`{|}~'", Address: "bob@example.com"},
+		// https://golang.org/issue/11292
+		{Name: "\"\\\x1f,\"", Address: "0@0"},
+		// https://golang.org/issue/12782
+		{Name: "naé, mée", Address: "test.mail@gmail.com"},
+	}
+
+	for i, test := range tests {
+		parsed, err := ParseAddress(test.String())
+		if err != nil {
+			t.Errorf("test #%d: ParseAddr(%q) error: %v", i, test.String(), err)
+			continue
+		}
+		if parsed.Name != test.Name {
+			t.Errorf("test #%d: Parsed name = %q; want %q", i, parsed.Name, test.Name)
+		}
+		if parsed.Address != test.Address {
+			t.Errorf("test #%d: Parsed address = %q; want %q", i, parsed.Address, test.Address)
+		}
+	}
+}
+
+func TestEmptyAddress(t *testing.T) {
+	parsed, err := ParseAddress("")
+	if parsed != nil || err == nil {
+		t.Errorf(`ParseAddress("") = %v, %v, want nil, error`, parsed, err)
+	}
+	list, err := ParseAddressList("")
+	if len(list) > 0 || err == nil {
+		t.Errorf(`ParseAddressList("") = %v, %v, want nil, error`, list, err)
+	}
+	list, err = ParseAddressList(",")
+	if len(list) > 0 || err == nil {
+		t.Errorf(`ParseAddressList("") = %v, %v, want nil, error`, list, err)
+	}
+	list, err = ParseAddressList("a@b c@d")
+	if len(list) > 0 || err == nil {
+		t.Errorf(`ParseAddressList("") = %v, %v, want nil, error`, list, err)
+	}
+}

--- a/pkg/pmapi/events.go
+++ b/pkg/pmapi/events.go
@@ -20,7 +20,8 @@ package pmapi
 import (
 	"encoding/json"
 	"net/http"
-	"net/mail"
+
+	mail "github.com/ProtonMail/proton-bridge/pkg/net/mail"
 )
 
 // Event represents changes since the last check.

--- a/pkg/pmapi/events_test.go
+++ b/pkg/pmapi/events_test.go
@@ -20,7 +20,6 @@ package pmapi
 import (
 	"fmt"
 	"net/http"
-	"net/mail"
 	"regexp"
 	"strconv"
 	"strings"
@@ -28,6 +27,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	mail "github.com/ProtonMail/proton-bridge/pkg/net/mail"
 )
 
 func TestClient_GetEvent(t *testing.T) {

--- a/pkg/pmapi/messages.go
+++ b/pkg/pmapi/messages.go
@@ -27,7 +27,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/mail"
 	"net/url"
 	"strconv"
 	"strings"
@@ -35,6 +34,7 @@ import (
 	"github.com/ProtonMail/gopenpgp/v2/crypto"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/crypto/openpgp/packet"
+	mail "github.com/ProtonMail/proton-bridge/pkg/net/mail"
 )
 
 // Header types.

--- a/test/mocks/smtp.go
+++ b/test/mocks/smtp.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"net/mail"
 	"os"
 	"strings"
 	"sync"
@@ -32,6 +31,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	mail "github.com/ProtonMail/proton-bridge/pkg/net/mail"
 )
 
 type SMTPClient struct {

--- a/test/store_checks_test.go
+++ b/test/store_checks_test.go
@@ -19,7 +19,6 @@ package tests
 
 import (
 	"fmt"
-	"net/mail"
 	"strings"
 	"time"
 
@@ -28,6 +27,7 @@ import (
 	"github.com/ProtonMail/proton-bridge/test/accounts"
 	"github.com/cucumber/godog"
 	"github.com/cucumber/godog/gherkin"
+	mail "github.com/ProtonMail/proton-bridge/pkg/net/mail"
 )
 
 func StoreChecksFeatureContext(s *godog.Suite) {

--- a/test/store_setup_test.go
+++ b/test/store_setup_test.go
@@ -19,7 +19,6 @@ package tests
 
 import (
 	"fmt"
-	"net/mail"
 	"strconv"
 	"strings"
 	"time"
@@ -27,6 +26,7 @@ import (
 	"github.com/ProtonMail/proton-bridge/pkg/pmapi"
 	"github.com/cucumber/godog"
 	"github.com/cucumber/godog/gherkin"
+	mail "github.com/ProtonMail/proton-bridge/pkg/net/mail"
 )
 
 func StoreSetupFeatureContext(s *godog.Suite) {

--- a/test/transfer_checks_test.go
+++ b/test/transfer_checks_test.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"net/mail"
 	"os"
 	"path/filepath"
 	"sort"
@@ -34,6 +33,7 @@ import (
 	"github.com/emersion/go-message"
 	"github.com/pkg/errors"
 	a "github.com/stretchr/testify/assert"
+	mail "github.com/ProtonMail/proton-bridge/pkg/net/mail"
 )
 
 func TransferChecksFeatureContext(s *godog.Suite) {


### PR DESCRIPTION
This is the proper way how to handle headers of non-standardly encoded messages. I am not entirely satisfied with how it is in `part.go`, but it is ready for review. The same technique should be probably applied for names of the attachments.

When a non-standard encoding is used it may be used on headers as well.