### PR TITLE
PR1 Two clean changes related to WordEncoder passing to AddressParser and use of Content-Type for deducing header encoding

### DIFF
--- a/pkg/message/header.go
+++ b/pkg/message/header.go
@@ -142,6 +142,7 @@ func GetAttachmentHeader(att *pmapi.Attachment) textproto.MIMEHeader {
 	return h
 }
 
+var addressParser = &mail.AddressParser{WordDecoder: pmmime.GetWordDecoder()}
 var reEmailComment = regexp.MustCompile("[(][^)]*[)]") // nolint[gochecknoglobals]
 
 // parseAddressComment removes the comments completely even though they should be allowed
@@ -156,7 +157,7 @@ func parseAddressList(val string) (addrs []*mail.Address, err error) {
 		return
 	}
 
-	addrs, err = mail.ParseAddressList(parseAddressComment(val))
+	addrs, err = addressParser.ParseList(val)
 	if err == nil {
 		if addrs == nil {
 			addrs = []*mail.Address{}
@@ -182,5 +183,5 @@ func parseAddressList(val string) (addrs []*mail.Address, err error) {
 	}
 	val = strings.Join(addrList, ", ")
 
-	return mail.ParseAddressList(val)
+	return addressParser.ParseList(val)
 }

--- a/pkg/message/parser.go
+++ b/pkg/message/parser.go
@@ -44,15 +44,15 @@ func Parse(r io.Reader, key, keyName string) (m *pmapi.Message, mimeBody, plainB
 		return
 	}
 
-	if err = convertForeignEncodings(p); err != nil {
-		err = errors.Wrap(err, "failed to convert foreign encodings")
+	m = pmapi.NewMessage()
+
+	if err = parseMessageHeader(p, m); err != nil {
+		err = errors.Wrap(err, "failed to parse message header")
 		return
 	}
 
-	m = pmapi.NewMessage()
-
-	if err = parseMessageHeader(m, p.Root().Header); err != nil {
-		err = errors.Wrap(err, "failed to parse message header")
+	if err = convertForeignEncodings(p); err != nil {
+		err = errors.Wrap(err, "failed to convert foreign encodings")
 		return
 	}
 
@@ -366,7 +366,9 @@ func attachPublicKey(p *parser.Part, key, keyName string) {
 }
 
 // NOTE: We should use our own ParseAddressList here.
-func parseMessageHeader(m *pmapi.Message, h message.Header) error { // nolint[funlen]
+func parseMessageHeader(p *parser.Parser, m *pmapi.Message) error { // nolint[funlen]
+	h := p.Root().Header;
+
 	mimeHeader, err := toMailHeader(h)
 	if err != nil {
 		return err
@@ -374,6 +376,7 @@ func parseMessageHeader(m *pmapi.Message, h message.Header) error { // nolint[fu
 	m.Header = mimeHeader
 
 	if err := forEachHeaderField(h, func(key, val string) error {
+		err, val = p.Root().ConvertHeaderToUTF8(val)
 		switch strings.ToLower(key) {
 		case "subject":
 			m.Subject, err = pmmime.DecodeHeader(val)
@@ -482,6 +485,7 @@ func forEachHeaderField(h message.Header, fn func(string, string) error) error {
 
 	return nil
 }
+
 func forEachDecodedHeaderField(h message.Header, fn func(string, string) error) error {
 	fields := h.Fields()
 

--- a/pkg/mime/encoding.go
+++ b/pkg/mime/encoding.go
@@ -45,6 +45,10 @@ var wordDec = &mime.WordDecoder{
 	},
 }
 
+func GetWordDecoder() *mime.WordDecoder {
+	return wordDec;
+}
+
 // Expects trimmed lowercase.
 func getEncoding(charset string) (enc encoding.Encoding, err error) {
 	preparsed := strings.Trim(strings.ToLower(charset), " \t\r\n")


### PR DESCRIPTION
Split from previous.