### PR TITLE
Don't rely on GOPATH being in $PATH.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ endif
 ${EXE_TARGET}: check-has-go gofiles ${RESOURCE_FILE} ${VENDOR_TARGET}
 	rm -rf deploy ${TARGET_OS} ${DEPLOY_DIR}
 	cp cmd/${TARGET_CMD}/main.go .
-	qtdeploy ${BUILD_FLAGS_GUI} ${QT_BUILD_TARGET}
+	$(shell go env GOPATH)/bin/qtdeploy ${BUILD_FLAGS_GUI} ${QT_BUILD_TARGET}
 	mv deploy cmd/${TARGET_CMD}
 	if [ "${EXE_QT_TARGET}" != "${EXE_TARGET}" ]; then mv ${EXE_QT_TARGET} ${EXE_TARGET}; fi
 	rm -rf ${TARGET_OS} main.go


### PR DESCRIPTION
I tried to build this project, and it failed with:

    $ make
    /usr/bin/go
    go install -v -tags=no_env github.com/therecipe/qt/cmd/...
    go mod vendor
    ln -sf /home/emilio/src/proton-bridge/vendor-cache/github.com/therecipe/env_linux_amd64_513 vendor/github.com/therecipe/env_linux_amd64_513
    rm -rf deploy linux cmd/Desktop-Bridge/deploy
    cp cmd/Desktop-Bridge/main.go .
    qtdeploy -tags=' build_qt' -ldflags '-X github.com/ProtonMail/proton-bridge/internal/constants.Version=1.6.9+git -X github.com/ProtonMail/proton-bridge/internal/constants.Revision=05dd137bc8 -X github.com/ProtonMail/proton-bridge/internal/constants.BuildTime=2021-04-04T21:11:41+0200' build desktop
    make: qtdeploy: No such file or directory

After some investigation, qtdeploy was installed by the build script in
GOPATH/bin, but the makefile seems to implicitly rely on that path being
in $PATH.

Instead of that, make sure to look at the right path, like other bits of
the Makefile do.