### PR TITLE
Linux keyring refactor

### DIFF
--- a/internal/frontend/cli-ie/utils.go
+++ b/internal/frontend/cli-ie/utils.go
@@ -104,7 +104,7 @@ func (f *frontendCLI) notifyNeedUpgrade() {
 func (f *frontendCLI) notifyCredentialsError() { // nolint[unused]
 	// Print in 80-column width.
 	f.Println("ProtonMail Import-Export app is not able to detect a supported password manager")
-	f.Println("(pass, gnome-keyring). Please install and set up a supported password manager")
+	f.Println("(pass, gnome-keyring or other provider of FreeDesktop Secret Service API). Please install and set up a supported password manager")
 	f.Println("and restart the application.")
 }
 

--- a/internal/frontend/cli/utils.go
+++ b/internal/frontend/cli/utils.go
@@ -104,7 +104,7 @@ func (f *frontendCLI) notifyNeedUpgrade() {
 func (f *frontendCLI) notifyCredentialsError() { // nolint[unused]
 	// Print in 80-column width.
 	f.Println("ProtonMail Bridge is not able to detect a supported password manager")
-	f.Println("(pass, gnome-keyring). Please install and set up a supported password manager")
+	f.Println("(pass, gnome-keyring or other provider of FreeDesktop Secret Service API). Please install and set up a supported password manager")
 	f.Println("and restart the application.")
 }
 

--- a/internal/frontend/qml/BridgeUI/DialogYesNo.qml
+++ b/internal/frontend/qml/BridgeUI/DialogYesNo.qml
@@ -321,7 +321,7 @@ Dialog {
                 target: root
                 currentIndex : 0
                 note     : qsTr(
-                    "%1 is not able to detected a supported password manager (pass, gnome-keyring). Please install and setup supported password manager and restart the application.",
+                    "%1 is not able to detected a supported password manager (pass, gnome-keyring or other provider of FreeDesktop Secret Service API). Please install and setup supported password manager and restart the application.",
                     "Error message when no keychain is detected"
                 ).arg(go.programTitle)
                 question         : qsTr("Do you want to close application now?", "when no password manager found." )

--- a/internal/frontend/qml/tst_Gui.qml
+++ b/internal/frontend/qml/tst_Gui.qml
@@ -281,8 +281,8 @@ Window {
 
         property bool hasNoKeychain : true
 
-        property var availableKeychain: ["pass-app", "gnome-keyring"]
-        property var selectedKeychain: "gnome-keyring"
+        property var availableKeychain: ["pass-app", "secret-service"]
+        property var selectedKeychain: "secret-service"
 
         property string wrongCredentials
         property string wrongMailboxPassword

--- a/pkg/keychain/helper_linux.go
+++ b/pkg/keychain/helper_linux.go
@@ -29,7 +29,7 @@ import (
 
 const (
 	Pass         = "pass-app"
-	GnomeKeyring = "gnome-keyring"
+	SecretService = "secret-service"
 )
 
 func init() { // nolint[noinit]
@@ -39,16 +39,14 @@ func init() { // nolint[noinit]
 		Helpers[Pass] = newPassHelper
 	}
 
-	if _, err := exec.LookPath("gnome-keyring"); err == nil {
-		Helpers[GnomeKeyring] = newGnomeKeyringHelper
-	}
+	Helpers[SecretService] = newSecretServiceHelper
 
 	// If Pass is available, use it by default.
 	// Otherwise, if GnomeKeyring is available, use it by default.
 	if _, ok := Helpers[Pass]; ok && isUsable(newPassHelper("")) {
 		defaultHelper = Pass
-	} else if _, ok := Helpers[GnomeKeyring]; ok && isUsable(newGnomeKeyringHelper("")) {
-		defaultHelper = GnomeKeyring
+	} else if _, ok := Helpers[SecretService]; ok && isUsable(newSecretServiceHelper("")) {
+		defaultHelper = SecretService
 	}
 }
 
@@ -56,7 +54,7 @@ func newPassHelper(string) (credentials.Helper, error) {
 	return &pass.Pass{}, nil
 }
 
-func newGnomeKeyringHelper(string) (credentials.Helper, error) {
+func newSecretServiceHelper(string) (credentials.Helper, error) {
 	return &secretservice.Secretservice{}, nil
 }
 

--- a/pkg/keychain/helper_linux.go
+++ b/pkg/keychain/helper_linux.go
@@ -42,7 +42,7 @@ func init() { // nolint[noinit]
 	Helpers[SecretService] = newSecretServiceHelper
 
 	// If Pass is available, use it by default.
-	// Otherwise, if GnomeKeyring is available, use it by default.
+	// Otherwise, if SecretService is available, use it by default.
 	if _, ok := Helpers[Pass]; ok && isUsable(newPassHelper("")) {
 		defaultHelper = Pass
 	} else if _, ok := Helpers[SecretService]; ok && isUsable(newSecretServiceHelper("")) {


### PR DESCRIPTION
Enables support for all apps which support Secret Service API, not only gnome-keyring for example KeepassXC or KWallet.﻿
Fixes: #176 #68 #14 
Tested on: 
KeepassXC with SecretService integration configured.