### PR TITLE
Support X-Keywords (and similar) message headers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -228,12 +228,12 @@ integration-test-bridge:
 	${MAKE} -C test test-bridge
 
 mocks:
-	mockgen --package mocks github.com/ProtonMail/proton-bridge/internal/users Locator,PanicHandler,CredentialsStorer,StoreMaker > internal/users/mocks/mocks.go
-	mockgen --package mocks github.com/ProtonMail/proton-bridge/pkg/listener Listener > internal/users/mocks/listener_mocks.go
-	mockgen --package mocks github.com/ProtonMail/proton-bridge/internal/store PanicHandler,BridgeUser,ChangeNotifier,Storer > internal/store/mocks/mocks.go
-	mockgen --package mocks github.com/ProtonMail/proton-bridge/pkg/listener Listener > internal/store/mocks/utils_mocks.go
-	mockgen --package mocks github.com/ProtonMail/proton-bridge/pkg/pmapi Client,Manager > pkg/pmapi/mocks/mocks.go
-	mockgen --package mocks github.com/ProtonMail/proton-bridge/pkg/message Fetcher > pkg/message/mocks/mocks.go
+	mockgen --build_flags=--mod=mod --package mocks github.com/ProtonMail/proton-bridge/internal/users Locator,PanicHandler,CredentialsStorer,StoreMaker > internal/users/mocks/mocks.go
+	mockgen --build_flags=--mod=mod --package mocks github.com/ProtonMail/proton-bridge/pkg/listener Listener > internal/users/mocks/listener_mocks.go
+	mockgen --build_flags=--mod=mod --package mocks github.com/ProtonMail/proton-bridge/internal/store PanicHandler,BridgeUser,ChangeNotifier,Storer > internal/store/mocks/mocks.go
+	mockgen --build_flags=--mod=mod --package mocks github.com/ProtonMail/proton-bridge/pkg/listener Listener > internal/store/mocks/utils_mocks.go
+	mockgen --build_flags=--mod=mod --package mocks github.com/ProtonMail/proton-bridge/pkg/pmapi Client,Manager > pkg/pmapi/mocks/mocks.go
+	mockgen --build_flags=--mod=mod --package mocks github.com/ProtonMail/proton-bridge/pkg/message Fetcher > pkg/message/mocks/mocks.go
 
 lint: gofiles lint-golang lint-license lint-dependencies lint-changelog
 

--- a/README.md
+++ b/README.md
@@ -1,26 +1,3 @@
-# Fork of ProtonMail Bridge to add support for `mu4e` tags as Labels
-
-This is a custom fork of ProtonMail Bridge. It adds support for tracking message tags added by `mu` and `mu4e` as ProtonMail Labels.
-
-**NOTE**: This is an experiment at this stage and should be treated as early alpha quality. Only very minor testing has been done and no optimisation has been performed. Therefore please only use this fork at your own risk; I am not responsible for any data loss or corruption that occurs due to its use.
-
-## Explanation of `mu4e` tags and ProtonMail labels
-
-When a message is tagged in `mu4e` a new "X-Keywords" header is added by default (although this can be changed). `mu` can use these headers to filter messages easily by those tags.
-
-With normal IMAP servers, this header can be saved as part of the message which means that tags are stored on the server. However, once a message is stored in ProtonMail it can no longer be modified; if the message with "X-Keywords" is pushed to ProtonMail via IMAP then this header will not be saved. Please see [this issue](https://protonmail.uservoice.com/forums/284483-protonmail/suggestions/43440678-support-for-custom-imap-headers-e-g-x-keywords) for further details.
-
-ProtonMail however offers support for Labels, which function very similarly to these tags, however these are not directly visible per message via ProtonMail Bridge. Instead, Labels act like IMAP folders, meaning that messages appear to be duplicated in one or more of these Label folders.
-
-## Changes in this fork
-
-This forked version of ProtonMail bridge currently has two modifications: -
-
-  - When fetching a message via IMAP, it will now create an "X-Keywords" header automatically with the names of all Labels assigned to the message; and
-  - When storing a message, it will extract the tags from an "X-Keywords" header (if present), convert them to Label IDs (creating new Labels if they are missing), and then assign those Labels to the message.
-
-The benefit of this is that messages can be tagged in `mu4e` and those tags will appear as Labels in ProtonMail. Furthermore, those tags/Labels will be present on all machines which are using this forked version of ProtonMail Bridge to fetch messages.
-
 # Proton Mail Bridge and Import Export app
 Copyright (c) 2022 Proton AG
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,26 @@
+# Fork of ProtonMail Bridge to add support for `mu4e` tags as Labels
+
+This is a custom fork of ProtonMail Bridge. It adds support for tracking message tags added by `mu` and `mu4e` as ProtonMail Labels.
+
+**NOTE**: This is an experiment at this stage and should be treated as early alpha quality. Only very minor testing has been done and no optimisation has been performed. Therefore please only use this fork at your own risk; I am not responsible for any data loss or corruption that occurs due to its use.
+
+## Explanation of `mu4e` tags and ProtonMail labels
+
+When a message is tagged in `mu4e` a new "X-Keywords" header is added by default (although this can be changed). `mu` can use these headers to filter messages easily by those tags.
+
+With normal IMAP servers, this header can be saved as part of the message which means that tags are stored on the server. However, once a message is stored in ProtonMail it can no longer be modified; if the message with "X-Keywords" is pushed to ProtonMail via IMAP then this header will not be saved. Please see [this issue](https://protonmail.uservoice.com/forums/284483-protonmail/suggestions/43440678-support-for-custom-imap-headers-e-g-x-keywords) for further details.
+
+ProtonMail however offers support for Labels, which function very similarly to these tags, however these are not directly visible per message via ProtonMail Bridge. Instead, Labels act like IMAP folders, meaning that messages appear to be duplicated in one or more of these Label folders.
+
+## Changes in this fork
+
+This forked version of ProtonMail bridge currently has two modifications: -
+
+  - When fetching a message via IMAP, it will now create an "X-Keywords" header automatically with the names of all Labels assigned to the message; and
+  - When storing a message, it will extract the tags from an "X-Keywords" header (if present), convert them to Label IDs (creating new Labels if they are missing), and then assign those Labels to the message.
+
+The benefit of this is that messages can be tagged in `mu4e` and those tags will appear as Labels in ProtonMail. Furthermore, those tags/Labels will be present on all machines which are using this forked version of ProtonMail Bridge to fetch messages.
+
 # Proton Mail Bridge and Import Export app
 Copyright (c) 2022 Proton AG
 

--- a/go.mod
+++ b/go.mod
@@ -42,9 +42,10 @@ require (
 	github.com/fatih/color v1.9.0
 	github.com/flynn-archive/go-shlex v0.0.0-20150515145356-3f9db97f8568 // indirect
 	github.com/getsentry/sentry-go v0.12.0
+	github.com/go-delve/delve v1.8.3 // indirect
 	github.com/go-resty/resty/v2 v2.6.0
 	github.com/godbus/dbus v4.1.0+incompatible
-	github.com/golang/mock v1.4.4
+	github.com/golang/mock v1.6.0
 	github.com/google/go-cmp v0.5.5
 	github.com/google/uuid v1.1.1
 	github.com/hashicorp/go-multierror v1.1.0
@@ -52,7 +53,6 @@ require (
 	github.com/keybase/go-keychain v0.0.0
 	github.com/kr/text v0.2.0 // indirect
 	github.com/logrusorgru/aurora v2.0.3+incompatible
-	github.com/mattn/go-runewidth v0.0.9 // indirect
 	github.com/miekg/dns v1.1.41
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce

--- a/go.sum
+++ b/go.sum
@@ -75,8 +75,11 @@ github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJm
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/chzyer/logex v1.1.10 h1:Swpa1K6QvQznwJRcfTfQJmTE72DqScAa40E+fbHEXEE=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
+github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 h1:q763qf9huN11kDQavWsoZXJNW3xEE4JJyHa5Q25/sd8=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
+github.com/cilium/ebpf v0.7.0 h1:1k/q3ATgxSXRdrmPfH8d7YK0GfqVsEKZAX9dQZvs56k=
+github.com/cilium/ebpf v0.7.0/go.mod h1:/oI2+1shJiTGAMgl6/RgJr36Eo1jzrRcAWbcXO2usCA=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/codegangsta/inject v0.0.0-20150114235600-33e0aa1cb7c0/go.mod h1:4Zcjuz89kmFXt9morQgcfYZAYZ5n8WHjt81YYWIwtTM=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
@@ -87,6 +90,7 @@ github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3Ee
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
+github.com/cosiner/argv v0.1.0/go.mod h1:EusR6TucWKX+zFgtdUsKT2Cvg45K5rtpCcWz4hK06d8=
 github.com/cpuguy83/go-md2man v1.0.10 h1:BSKMNlYxDvnunlTymqtgONjNnaRV1sTpcovwwjF22jk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
@@ -109,6 +113,7 @@ github.com/danieljoos/wincred v1.1.0/go.mod h1:XYlo+eRTsVA9aHGp7NGjFkPla4m+DCL7h
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/derekparker/trie v0.0.0-20200317170641-1fdf38b7b0e9/go.mod h1:D6ICZm05D9VN1n/8iOtBxLpXtoGp6HDFUJ1RNVieOSE=
 github.com/dgraph-io/badger v1.6.0/go.mod h1:zwt7syl517jmP8s94KqSxTlM6IMsdhYy6psNgSztDR4=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
@@ -145,6 +150,7 @@ github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/flynn-archive/go-shlex v0.0.0-20150515145356-3f9db97f8568 h1:BMXYYRWTLOJKlh+lOBt6nUQgXAfB7oVIQt5cNreqSLI=
 github.com/flynn-archive/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:rZfgFAXFS/z/lEd6LJmf9HVZ1LkgYiHx5pHhV5DR16M=
+github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM0I9ntUbOk+k=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/gavv/httpexpect v2.0.0+incompatible/go.mod h1:x+9tiU1YnrOvnB725RkpoLv1M62hOWzwo5OXotisrKc=
 github.com/getsentry/sentry-go v0.12.0 h1:era7g0re5iY13bHSdN/xMkyV+5zZppjRVQhZrXCaEIk=
@@ -153,6 +159,9 @@ github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeME
 github.com/gin-contrib/sse v0.0.0-20190301062529-5545eab6dad3/go.mod h1:VJ0WA2NBN22VlZ2dKZQPAPnyWw5XTlK1KymzLKsr59s=
 github.com/gin-gonic/gin v1.4.0/go.mod h1:OW2EZn3DO8Ln9oIKOvM++LBO+5UPHJJDH72/q/3rZdM=
 github.com/go-check/check v0.0.0-20180628173108-788fd7840127/go.mod h1:9ES+weclKsC9YodN5RgxqK/VD9HM9JsCSh7rNhMZE98=
+github.com/go-delve/delve v1.8.3 h1:D0jTF4DHZQNBPMQwAPe0WtZV4I4gEeWOsSt4VmhGys8=
+github.com/go-delve/delve v1.8.3/go.mod h1:XB6XKpI5DqMCNai0MkNPVbrd3OtBovJ/vfcVofkWy/k=
+github.com/go-delve/liner v1.2.2-1/go.mod h1:biJCRbqp51wS+I92HMqn5H8/A0PAhxn2vyOT+JqhiGI=
 github.com/go-errors/errors v1.0.1 h1:LUHzmkK3GUKUrL/1gfBUxAHzcev3apQlezX/+O7ma6w=
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
@@ -180,6 +189,8 @@ github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfb
 github.com/golang/mock v1.3.1/go.mod h1:sBzyDLLjw3U8JLTeZvSv8jJB+tU5PVekmnlKIyFUx0Y=
 github.com/golang/mock v1.4.4 h1:l75CXGRSwbaYNpl/Z2X1XIIAMSCquvXgpVZDhwEIJsc=
 github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71h+4=
+github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
+github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -191,6 +202,7 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-dap v0.6.0/go.mod h1:5q8aYQFnHOAZEMP+6vmq25HKYAEwE+LF5yh7JKrrhSQ=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
@@ -279,6 +291,7 @@ github.com/klauspost/compress v1.9.7/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0
 github.com/klauspost/cpuid v1.2.1/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
@@ -307,9 +320,12 @@ github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOA
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9Y=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
+github.com/mattn/go-runewidth v0.0.3/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+github.com/mattn/go-runewidth v0.0.13 h1:lTGmDsbAYt5DmK6OnoV7EuIF1wEIFAcxld6ypU4OSgU=
+github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mattn/goveralls v0.0.2/go.mod h1:8d1ZMHsd7fW6IRPKQh46F2WRpyib5/X4FOpevwGNQEw=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mediocregopher/radix/v3 v3.4.2/go.mod h1:8FL3F6UQRXHXIBSPUs5h0RybMF8i4n7wVopoX3x7Bv8=
@@ -369,6 +385,8 @@ github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/ricochet2200/go-disk-usage/du v0.0.0-20210707232629-ac9918953285 h1:d54EL9l+XteliUfUCGsEwwuk65dmmxX85VXF+9T6+50=
 github.com/ricochet2200/go-disk-usage/du v0.0.0-20210707232629-ac9918953285/go.mod h1:fxIDly1xtudczrZeOOlfaUvd2OPb2qZAPuWdU2BsBTk=
+github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
+github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNueLj0oo=
@@ -385,6 +403,7 @@ github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeV
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
+github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/sirupsen/logrus v1.7.0 h1:ShrD1U9pZB12TX0cVy0DtePoCH97K8EtX+mg7ZARUtM=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
@@ -397,6 +416,7 @@ github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=
 github.com/spf13/cobra v1.1.1/go.mod h1:WnodtKOvamDL/PwE2M4iKs8aMDBZ5Q5klgD3qfVJQMI=
+github.com/spf13/cobra v1.1.3/go.mod h1:pGADOWyqRD/YMrPZigI/zbliZ2wVD/23d+is3pSWzOo=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
@@ -449,14 +469,18 @@ github.com/yalp/jsonpath v0.0.0-20180802001716-5cc68e5049a0/go.mod h1:/LWChgwKmv
 github.com/yudai/gojsondiff v1.0.0/go.mod h1:AY32+k2cwILAkW1fbgxQ5mUmMiZFgLIV+FBNExI05xg=
 github.com/yudai/golcs v0.0.0-20170316035057-ecda9a501e82/go.mod h1:lgjkn3NuSvDfVJdfcVVdX+jpBxNmX4rDAzaS45IcYoM=
 github.com/yudai/pp v2.0.1+incompatible/go.mod h1:PuxR/8QJ7cyCkFp/aUDS+JY727OFEZkTdatxwunjIkc=
+github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
+github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.6 h1:/ecaJf0sk1l4l6V4awd65v2C3ILy7MSj+s/x1ADCIMU=
 go.etcd.io/bbolt v1.3.6/go.mod h1:qXsaaIqmgQH0T+OPdb99Bf+PKfBBQVAdyD6TY9G8XM4=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
+go.starlark.net v0.0.0-20200821142938-949cc6f4b097/go.mod h1:f0znQkUKRrkk36XxWbGjMqQM8wGv/xHBVE2qc3B5oFU=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
+golang.org/x/arch v0.0.0-20190927153633-4e8777c89be4/go.mod h1:flIaEI6LNU6xOCD5PaJvn9wGP0agmIOqjrtsKGRguv4=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181029021203-45a5f77698d3/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
@@ -495,6 +519,9 @@ golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKG
 golang.org/x/mod v0.1.0/go.mod h1:0QHyrYULN0/3qlju5TqG8bIK38QM8yzMo5ekMj3DlcY=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.1.1-0.20191209134235-331c550502dd/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.4.2 h1:Gz96sIWK3OalVv/I/qNygP42zyoKp3xptRVCWRFEBvo=
+golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.5.1/go.mod h1:5OXOZSfqPIIbmVBIIKWRFfZjPR0E5r58TLhUjH0a2Ro=
 golang.org/x/net v0.0.0-20180218175443-cbe0f9307d01/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -520,6 +547,7 @@ golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20211008194852-3b03d305991f h1:1scJEYZBaF48BaG6tYbtxmLcXqwYGSfGcMoStTqkkIw=
 golang.org/x/net v0.0.0-20211008194852-3b03d305991f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4 h1:HVyaeDAYux4pnY+D/SiwmLOR36ewZ4iGQIIrtnuCjFA=
 golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
@@ -560,6 +588,7 @@ golang.org/x/sys v0.0.0-20191025021431-6c3a3bfe00ae/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200923182605-d9f96fdee20d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -567,10 +596,14 @@ golang.org/x/sys v0.0.0-20210303074136-134d130e1a04/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210906170528-6f6e22806c34/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211117180635-dee7805ff2e1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e h1:fLOSk5Q00efkSvAm+4xcoXD+RRmLmmulPn5I3Y9F2EM=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220111092808-5a964db01320 h1:0jf+tOCoZ3LyutmCOWpVni1chK4VfFLhRsDK7MhqGRY=
@@ -612,10 +645,15 @@ golang.org/x/tools v0.0.0-20191112195655-aa38f8e97acc/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200117012304-6edc0a871e69 h1:yBHHx+XZqXJBm6Exke3N7V9gnlsyXxoCPEb1yVenjfk=
 golang.org/x/tools v0.0.0-20200117012304-6edc0a871e69/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/tools v0.1.1 h1:wGiQel/hW0NnEkJUk8lbzkX2gFJU6PFxf1v5OlCfuOs=
+golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
+golang.org/x/tools v0.1.9/go.mod h1:nABZi5QlRsZVlzPpHl034qft6wpY4eDcsTt5AaioBiU=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=
 google.golang.org/api v0.8.0/go.mod h1:o4eAsZoiT+ibD93RtjEohWalFOjRDx6CVaqeizhEnKg=
@@ -658,6 +696,7 @@ gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20191120175047-4206685974f2/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 h1:tQIYjPdBoyREyB9XMu+nnTclpTYkz2zFM+lzLJFO4gQ=
@@ -670,3 +709,4 @@ howett.net/plist v0.0.0-20181124034731-591f970eefbb/go.mod h1:vMygbs4qMhSZSc4lCU
 howett.net/plist v1.0.0 h1:7CrbWYbPPO/PyNy38b2EB/+gYbjCe2DXBxgtOOZbSQM=
 howett.net/plist v1.0.0/go.mod h1:lqaXoTrLY4hg8tnEzNru53gicrbv7rrk+2xJA/7hw9g=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
+rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=

--- a/internal/frontend/cli/frontend.go
+++ b/internal/frontend/cli/frontend.go
@@ -69,6 +69,32 @@ func New( //nolint:funlen
 		restarter: restarter,
 	}
 
+	// Keyword commands
+	keywordCmd := &ishell.Cmd{
+		Name:    "keywords",
+		Help:    "Commands used for testing X-Keywords support",
+		Aliases: []string{"kw"},
+	}
+	keywordCmd.AddCmd(&ishell.Cmd{
+		Name:    "get-message",
+		Help:    "Fetch and show a Message by ID",
+		Aliases: []string{"fm"},
+		Func:    fe.getMessageById,
+	})
+	keywordCmd.AddCmd(&ishell.Cmd{
+		Name:    "get-messages",
+		Help:    "Fetch and show all Messages",
+		Aliases: []string{"fm"},
+		Func:    fe.getMessages,
+	})
+	keywordCmd.AddCmd(&ishell.Cmd{
+		Name:    "list-labels",
+		Help:    "Fetch and show all defined Labels",
+		Aliases: []string{"ll"},
+		Func:    fe.listAllLabels,
+	})
+	fe.AddCmd(keywordCmd)
+
 	// Clear commands.
 	clearCmd := &ishell.Cmd{Name: "clear",
 		Help:    "remove stored accounts and preferences. (alias: cl)",

--- a/internal/imap/mailbox_append.go
+++ b/internal/imap/mailbox_append.go
@@ -66,55 +66,7 @@ func (im *imapMailbox) createMessage(imapFlags []string, date time.Time, r imap.
 		return err
 	}
 
-	im.log.Info(fmt.Sprintf("Found X-Keywords header: %s", m.Header.Get("X-Keywords")))
-
-	// Convert all X-Keywords labels names to IDs (creating if necessary)
-	labelNames := strings.Split(m.Header.Get("X-Keywords"), ",")
-	var labels []*pmapi.Label
-	labels = im.user.client().GetLabelCache()
-	if len(labels) == 0 {
-		labels2, err := im.user.client().ListLabels(context.Background())
-		if err != nil {
-			im.log.Error(err)
-		} else {
-			labels = labels2
-		}
-	}
-
-	labelIDs := []string{}
-	found := false
-	for _, keyword := range labelNames {
-		keyword = strings.TrimSpace(keyword)
-		found = false
-		for _, label := range labels {
-			if label.Name == keyword {
-				labelIDs = append(labelIDs, label.ID)
-				found = true
-				break
-			}
-		}
-
-		if !found {
-			// Create new Label and append ID
-			im.log.Warn(fmt.Sprintf("Label \"%s\" not found, creating...", keyword))
-			label := pmapi.Label{
-				Name:      keyword,
-				Path:      keyword,
-				Color:     pmapi.LeastUsedColor(pmapi.LabelColors),
-				Display:   0,
-				Exclusive: false,
-				Type:      1,
-				Notify:    false,
-			}
-			newLabel, err := im.user.client().CreateLabel(context.Background(), &label)
-			if err != nil {
-				im.log.Error(err)
-			} else {
-				im.log.Info(fmt.Sprintf("Created new label \"%s\" (ID: %s)", keyword, newLabel.ID))
-				labelIDs = append(labelIDs, newLabel.ID)
-			}
-		}
-	}
+	labelIDs := im.getLabelIDsFromKeywords(m, context.Background())
 
 	im.log.Info("Append the following label IDs to m.LabelIDs: -")
 	im.log.Info(labelIDs)
@@ -253,7 +205,7 @@ func (im *imapMailbox) labelExistingMessage(msg storeMessageProvider, labelIDs [
 		return err
 	}
 
-	im.log.Info(fmt.Sprintf("Message already exists (ID: %s), adding labels...", msg.ID()))
+	im.log.Infof("Message already exists (ID: %s), adding labels...", msg.ID())
 
 	apiMsg, err := im.user.client().GetMessage(
 		context.Background(),
@@ -281,9 +233,9 @@ func (im *imapMailbox) labelExistingMessage(msg storeMessageProvider, labelIDs [
 				}
 			}
 		}
-		im.log.Info("Removing the following labels: -")
-		im.log.Info(removeLabelIDs)
+
 		for _, remLabelID := range removeLabelIDs {
+			im.log.Infof("Removing label ID %s...", remLabelID)
 			im.user.client().UnlabelMessages(
 				context.Background(),
 				[]string{msg.ID()},
@@ -293,7 +245,7 @@ func (im *imapMailbox) labelExistingMessage(msg storeMessageProvider, labelIDs [
 	}
 
 	for _, labelID := range labelIDs {
-		im.log.Info(fmt.Sprintf("Adding label ID %s...", labelID))
+		im.log.Infof("Adding label ID %s...", labelID)
 		im.user.client().LabelMessages(
 			context.Background(),
 			[]string{msg.ID()},
@@ -379,4 +331,67 @@ func (im *imapMailbox) importMessage(kr *crypto.KeyRing, hdr textproto.Header, b
 	}
 
 	return uidplus.AppendResponse(im.storeMailbox.UIDValidity(), im.storeMailbox.GetUIDList([]string{messageID}))
+}
+
+func (im *imapMailbox) getLabelIDsFromKeywords(m *pmapi.Message, ctx context.Context) []string {
+	var keywordsHeader string
+	keywordsHeader = m.Header.Get("X-Keywords")
+	if len(keywordsHeader) == 0 {
+	    keywordsHeader = m.Header.Get("X-Label")
+	}
+	if len(keywordsHeader) == 0 {
+	    keywordsHeader = m.Header.Get("Keywords")
+	}
+	if len(keywordsHeader) == 0 {
+		return []string{}
+	}
+	im.log.Infof("Found keywords: %s", keywordsHeader)
+
+	// Convert all keywords (label names) to IDs (creating if necessary)
+	labelNames := strings.Split(keywordsHeader, ",")
+	var labels []*pmapi.Label
+	labels = im.user.client().GetLabelCache()
+	if len(labels) == 0 {
+		labels2, err := im.user.client().ListLabels(ctx)
+		if err != nil {
+			im.log.Error(err)
+		} else {
+			labels = labels2
+		}
+	}
+	labelIDs := []string{}
+	found := false
+	for _, keyword := range labelNames {
+		keyword = strings.TrimSpace(keyword)
+		found = false
+		for _, label := range labels {
+			if label.Name == keyword {
+				labelIDs = append(labelIDs, label.ID)
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			// Create new Label and append ID
+			im.log.Warnf("Label \"%s\" not found, creating...", keyword)
+			label := pmapi.Label{
+				Name:      keyword,
+				Path:      keyword,
+				Color:     pmapi.LeastUsedColor(pmapi.LabelColors),
+				Display:   0,
+				Exclusive: false,
+				Type:      1,
+				Notify:    false,
+			}
+			newLabel, err := im.user.client().CreateLabel(ctx, &label)
+			if err != nil {
+				im.log.Error(err)
+			} else {
+				im.log.Infof("Created new label \"%s\" (ID: %s)", keyword, newLabel.ID)
+				labelIDs = append(labelIDs, newLabel.ID)
+			}
+		}
+	}
+	return labelIDs
 }

--- a/internal/store/cache_test.go
+++ b/internal/store/cache_test.go
@@ -41,7 +41,7 @@ func TestIsCachedCrashRecovers(t *testing.T) {
 	r.False(m.store.IsCached("msg1"))
 }
 
-var wantLiteral = []byte("Mime-Version: 1.0\r\nContent-Transfer-Encoding: quoted-printable\r\nContent-Type: \r\nReferences:  <msg1@protonmail.internalid>\r\nX-Pm-Date: Thu, 01 Jan 1970 00:00:00 +0000\r\nX-Pm-External-Id: <>\r\nX-Pm-Internal-Id: msg1\r\nX-Original-Date: Mon, 01 Jan 0001 00:00:00 +0000\r\nDate: Fri, 13 Aug 1982 00:00:00 +0000\r\nMessage-Id: <msg1@protonmail.internalid>\r\nSubject: subject\r\n\r\n")
+var wantLiteral = []byte("Mime-Version: 1.0\r\nContent-Transfer-Encoding: quoted-printable\r\nContent-Type: \r\nReferences:  <msg1@protonmail.internalid>\r\nX-Pm-Date: Thu, 01 Jan 1970 00:00:00 +0000\r\nX-Pm-External-Id: <>\r\nX-Keywords: \r\nX-Pm-Internal-Id: msg1\r\nX-Original-Date: Mon, 01 Jan 0001 00:00:00 +0000\r\nDate: Fri, 13 Aug 1982 00:00:00 +0000\r\nMessage-Id: <msg1@protonmail.internalid>\r\nSubject: subject\r\n\r\n")
 
 func TestGetCachedMessageOK(t *testing.T) {
 	r := require.New(t)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -400,6 +400,7 @@ func (store *Store) newBuildJob(ctx context.Context, messageID string, priority 
 			AddExternalID:          true, // Whether to include ExternalID as X-Pm-External-Id.
 			AddMessageDate:         true, // Whether to include message time as X-Pm-Date.
 			AddMessageIDReference:  true, // Whether to include the MessageID in References.
+			AddXKeywords:           true, // Whether to include an "X-Keywords" header with all of the Message Labels.
 		},
 		priority,
 	)

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -195,6 +195,13 @@ func (mocks *mocksForStore) newStoreNoEvents(t *testing.T, combinedMode bool, ms
 	})
 	mocks.client.EXPECT().ListLabels(gomock.Any()).AnyTimes()
 	mocks.client.EXPECT().CountMessages(gomock.Any(), "")
+	mocks.client.EXPECT().GetLabelCache().Return([]*pmapi.Label{
+		{ID: "label1", Name: "Foo", Color: "blue", Exclusive: false, Order: 2},
+		{ID: "label2", Name: "Bar", Color: "green", Exclusive: false, Order: 1},
+		{ID: "folder1", Name: "One", Color: "red", Exclusive: true, Order: 1},
+		{ID: "folder2", Name: "Two", Color: "orange", Exclusive: true, Order: 2},
+	}).AnyTimes()
+	mocks.client.EXPECT().LabelMessages(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 
 	// Call to get latest event ID and then to process first event.
 	eventAfterSyncRequested := make(chan struct{})

--- a/internal/users/users_test.go
+++ b/internal/users/users_test.go
@@ -269,6 +269,13 @@ func mockAddingConnectedUser(t *testing.T, m mocks) {
 		m.pmapiClient.EXPECT().Unlock(gomock.Any(), testCredentials.MailboxPassword).Return(nil),
 		m.pmapiClient.EXPECT().CurrentUser(gomock.Any()).Return(testPMAPIUser, nil),
 		m.pmapiClient.EXPECT().Addresses().Return([]*pmapi.Address{testPMAPIAddress}),
+		m.pmapiClient.EXPECT().GetLabelCache().Return([]*pmapi.Label{
+			{ID: "label1", Name: "Foo", Color: "blue", Exclusive: false, Order: 2},
+			{ID: "label2", Name: "Bar", Color: "green", Exclusive: false, Order: 1},
+			{ID: "folder1", Name: "One", Color: "red", Exclusive: true, Order: 1},
+			{ID: "folder2", Name: "Two", Color: "orange", Exclusive: true, Order: 2},
+		}).AnyTimes(),
+		m.pmapiClient.EXPECT().LabelMessages(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes(),
 		m.credentialsStore.EXPECT().Add("user", "username", testAuthRefresh.UID, testAuthRefresh.RefreshToken, testCredentials.MailboxPassword, []string{testPMAPIAddress.Email}).Return(testCredentials, nil),
 		m.credentialsStore.EXPECT().Get("user").Return(testCredentials, nil),
 	)

--- a/pkg/message/build.go
+++ b/pkg/message/build.go
@@ -19,7 +19,6 @@ package message
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"sync"
@@ -28,7 +27,6 @@ import (
 	"github.com/ProtonMail/proton-bridge/pkg/pmapi"
 	"github.com/ProtonMail/proton-bridge/pkg/pool"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -198,7 +196,6 @@ func newFetcherWorkFunc(attachmentPool *pool.Pool) pool.WorkFunc {
 		if err != nil {
 			return nil, err
 		}
-		msg.LabelNames = getMessageLabelStrings(req.ctx, req.fetcher, msg)
 
 		attData := make(map[string][]byte)
 
@@ -234,31 +231,4 @@ func newFetcherWorkFunc(attachmentPool *pool.Pool) pool.WorkFunc {
 
 		return buildRFC822(kr, msg, attData, req.options)
 	}
-}
-
-func getMessageLabelStrings(ctx context.Context, c Fetcher, msg *pmapi.Message) []string {
-	logrus.Info(fmt.Sprintf("Fetching message labels names for message ID %s...", msg.ID))
-
-	res := []string{}
-
-	var labels []*pmapi.Label
-	labels = c.GetLabelCache()
-	if len(labels) == 0 {
-		labels2, err := c.ListLabels(ctx)
-		if err != nil {
-			return res
-		}
-		labels = labels2
-	}
-
-	for _, lid := range msg.LabelIDs {
-		for _, label := range labels {
-			if label.ID == lid {
-				res = append(res, label.Name)
-				break
-			}
-		}
-	}
-
-	return res
 }

--- a/pkg/message/build_framework_test.go
+++ b/pkg/message/build_framework_test.go
@@ -51,6 +51,13 @@ func newTestFetcher(
 	}
 
 	f.EXPECT().KeyRingForAddressID(msg.AddressID).Return(kr, nil)
+	f.EXPECT().GetLabelCache().Return([]*pmapi.Label{
+		{ID: "label1", Name: "Foo", Color: "blue", Exclusive: false, Order: 2},
+		{ID: "label2", Name: "Bar", Color: "green", Exclusive: false, Order: 1},
+		{ID: "folder1", Name: "One", Color: "red", Exclusive: true, Order: 1},
+		{ID: "folder2", Name: "Two", Color: "orange", Exclusive: true, Order: 2},
+	}).AnyTimes()
+	f.EXPECT().ListLabels(gomock.Any()).AnyTimes()
 
 	return f
 }

--- a/pkg/message/build_job.go
+++ b/pkg/message/build_job.go
@@ -24,4 +24,5 @@ type JobOptions struct {
 	AddExternalID          bool // Whether to include ExternalID as X-Pm-External-Id.
 	AddMessageDate         bool // Whether to include message time as X-Pm-Date.
 	AddMessageIDReference  bool // Whether to include the MessageID in References.
+	AddXKeywords           bool // Whether to include an "X-Keywords" header with all of the Message Labels.
 }

--- a/pkg/message/build_rfc822.go
+++ b/pkg/message/build_rfc822.go
@@ -417,6 +417,12 @@ func getMessageHeader(msg *pmapi.Message, opts JobOptions) message.Header { //no
 		hdr.Set("X-Pm-Internal-Id", msg.ID)
 	}
 
+	// Add X-Keywords header based on the Message Labels
+	if opts.AddXKeywords {
+		log.Info("Adding X-Keywords to message headers...")
+		hdr.Set("X-Keywords", strings.Join(msg.LabelNames, ","))
+	}
+
 	// Set our external ID if requested.
 	// This was useful during debugging of applemail recovered messages; doesn't help with any behaviour.
 	if opts.AddExternalID {

--- a/pkg/message/mocks/mocks.go
+++ b/pkg/message/mocks/mocks.go
@@ -52,6 +52,20 @@ func (mr *MockFetcherMockRecorder) GetAttachment(arg0, arg1 interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAttachment", reflect.TypeOf((*MockFetcher)(nil).GetAttachment), arg0, arg1)
 }
 
+// GetLabelCache mocks base method.
+func (m *MockFetcher) GetLabelCache() []*pmapi.Label {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetLabelCache")
+	ret0, _ := ret[0].([]*pmapi.Label)
+	return ret0
+}
+
+// GetLabelCache indicates an expected call of GetLabelCache.
+func (mr *MockFetcherMockRecorder) GetLabelCache() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLabelCache", reflect.TypeOf((*MockFetcher)(nil).GetLabelCache))
+}
+
 // GetMessage mocks base method.
 func (m *MockFetcher) GetMessage(arg0 context.Context, arg1 string) (*pmapi.Message, error) {
 	m.ctrl.T.Helper()
@@ -80,4 +94,19 @@ func (m *MockFetcher) KeyRingForAddressID(arg0 string) (*crypto.KeyRing, error) 
 func (mr *MockFetcherMockRecorder) KeyRingForAddressID(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "KeyRingForAddressID", reflect.TypeOf((*MockFetcher)(nil).KeyRingForAddressID), arg0)
+}
+
+// ListLabels mocks base method.
+func (m *MockFetcher) ListLabels(arg0 context.Context) ([]*pmapi.Label, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListLabels", arg0)
+	ret0, _ := ret[0].([]*pmapi.Label)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListLabels indicates an expected call of ListLabels.
+func (mr *MockFetcherMockRecorder) ListLabels(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListLabels", reflect.TypeOf((*MockFetcher)(nil).ListLabels), arg0)
 }

--- a/pkg/pmapi/client.go
+++ b/pkg/pmapi/client.go
@@ -41,6 +41,9 @@ type client struct {
 	addrKeyRing map[string]*crypto.KeyRing
 	keyRingLock sync.Locker
 
+	// Cache of all Labels
+	allLabels []*Label
+
 	exp time.Time
 }
 
@@ -117,4 +120,14 @@ func (c *client) do(ctx context.Context, fn func(*resty.Request) (*resty.Respons
 	}
 
 	return res, nil
+}
+
+// GetLabelCache returns the current Label cache
+func (c *client) GetLabelCache() []*Label {
+	return c.allLabels
+}
+
+// Clear the "all Labels" cache
+func (c *client) ClearLabelsCache() {
+	c.allLabels = []*Label{}
 }

--- a/pkg/pmapi/client_types.go
+++ b/pkg/pmapi/client_types.go
@@ -75,6 +75,8 @@ type Client interface {
 	GetUserKeyRing() (*crypto.KeyRing, error)
 	KeyRingForAddressID(string) (kr *crypto.KeyRing, err error)
 	GetPublicKeysForEmail(context.Context, string) ([]PublicKey, bool, error)
+
+	GetLabelCache() []*Label
 }
 
 type AuthRefreshHandler func(*AuthRefresh)

--- a/pkg/pmapi/labels.go
+++ b/pkg/pmapi/labels.go
@@ -89,7 +89,14 @@ type Label struct { //nolint:maligned
 }
 
 func (c *client) ListLabels(ctx context.Context) (labels []*Label, err error) {
-	return c.listLabelType(ctx, LabelTypeMailbox)
+	labels, err = c.listLabelType(ctx, LabelTypeMailbox)
+
+	// Cache list of all Labels
+	if err == nil {
+		copy(c.allLabels, labels)
+	}
+
+	return labels, err
 }
 
 func (c *client) ListContactGroups(ctx context.Context) (labels []*Label, err error) {
@@ -133,6 +140,8 @@ func (c *client) CreateLabel(ctx context.Context, label *Label) (created *Label,
 		return nil, err
 	}
 
+	c.ClearLabelsCache()
+
 	return res.Label, nil
 }
 
@@ -154,6 +163,8 @@ func (c *client) UpdateLabel(ctx context.Context, label *Label) (updated *Label,
 		return nil, err
 	}
 
+	c.ClearLabelsCache()
+
 	return res.Label, nil
 }
 
@@ -164,6 +175,8 @@ func (c *client) DeleteLabel(ctx context.Context, labelID string) error {
 	}); err != nil {
 		return err
 	}
+
+	c.ClearLabelsCache()
 
 	return nil
 }

--- a/pkg/pmapi/messages.go
+++ b/pkg/pmapi/messages.go
@@ -746,7 +746,7 @@ func ComputeMessageFlagsByLabels(labels []string) (flag int64) {
 }
 
 func getMessageLabelStrings(ctx context.Context, c *client, msg *Message) []string {
-	logrus.Info(fmt.Sprintf("Fetching message label names for message ID %s...", msg.ID))
+	logrus.Infof("Fetching message label names for message ID %s...", msg.ID)
 
 	res := []string{}
 

--- a/pkg/pmapi/messages.go
+++ b/pkg/pmapi/messages.go
@@ -174,6 +174,7 @@ type Message struct {
 	Body           string `json:",omitempty"`
 	Attachments    []*Attachment
 	LabelIDs       []string
+	LabelNames     []string
 	ExternalID     string
 	Header         mail.Header
 	MIMEType       string
@@ -187,6 +188,7 @@ func NewMessage() *Message {
 		BCCList:     []*mail.Address{},
 		Attachments: []*Attachment{},
 		LabelIDs:    []string{},
+		LabelNames:  []string{},
 	}
 }
 
@@ -738,3 +740,4 @@ func ComputeMessageFlagsByLabels(labels []string) (flag int64) {
 
 	return flag
 }
+

--- a/pkg/pmapi/mocks/mocks.go
+++ b/pkg/pmapi/mocks/mocks.go
@@ -316,6 +316,20 @@ func (mr *MockClientMockRecorder) GetEvent(arg0, arg1 interface{}) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEvent", reflect.TypeOf((*MockClient)(nil).GetEvent), arg0, arg1)
 }
 
+// GetLabelCache mocks base method.
+func (m *MockClient) GetLabelCache() []*pmapi.Label {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetLabelCache")
+	ret0, _ := ret[0].([]*pmapi.Label)
+	return ret0
+}
+
+// GetLabelCache indicates an expected call of GetLabelCache.
+func (mr *MockClientMockRecorder) GetLabelCache() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLabelCache", reflect.TypeOf((*MockClient)(nil).GetLabelCache))
+}
+
 // GetMailSettings mocks base method.
 func (m *MockClient) GetMailSettings(arg0 context.Context) (pmapi.MailSettings, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
I use `mbsync`/`isync`, Maildir-utils `mu4e` to manage my mail and I rely heavily on tagging messages rather than filing them into separate folders.

This PR adds support for message headers such as `X-Keywords` which are used for tagging messages. When fetching a message from ProtonMail, all labels assigned to the message are fetched and an "X-Keywords" header is added with all of the label names. When appending a message via IMAP, the list of tags is read from the `X-Keywords` (or similar) header and used to assign ProtonMail labels. Labels are automatically added and removed based on the value of this header and missing labels are automatically created.

I think this PR adds an important feature to ProtonMail Bridge, especially for people like me who rely on message tagging. It has become very important in my daily workflow and I think it could benefit others too. I would be extremely grateful if this could be considered for inclusion upstream, perhaps adding a toggle option if it's not suitable for everybody?

Thank you very much in advance.