### PR TITLE
XDG_CACHE_HOME Directory Incorrect

### DIFF
--- a/internal/frontend/bridge-gui/bridgepp/bridgepp/BridgeUtils.cpp
+++ b/internal/frontend/bridge-gui/bridgepp/bridgepp/BridgeUtils.cpp
@@ -84,11 +84,12 @@ QString userConfigDir()
     dir += "/Library/Application Support";
 #else
     dir = qgetenv ("XDG_CONFIG_HOME");
-        if (dir.isEmpty())
+    if (dir.isEmpty()) {
             dir = qgetenv ("HOME");
         if (dir.isEmpty())
             throw Exception("neither $XDG_CONFIG_HOME nor $HOME are defined");
         dir += "/.config";
+}
 #endif
     QString const folder = QDir(dir).absoluteFilePath(configFolder);
     QDir().mkpath(folder);
@@ -115,11 +116,12 @@ QString userCacheDir()
     dir += "/Library/Caches";
 #else
     dir = qgetenv ("XDG_CACHE_HOME");
-        if (dir.isEmpty())
+    if (dir.isEmpty())  {
             dir = qgetenv ("HOME");
         if (dir.isEmpty())
             throw Exception("neither XDG_CACHE_HOME nor $HOME are defined");
         dir += "/.cache";
+}
 #endif
 
     QString const folder = QDir(dir).absoluteFilePath(configFolder);


### PR DESCRIPTION
Currently, if `XDG_CACHE_HOME` directory is set then `proton-bridge` creates its cache directory in `$XDG_CACHE_HOME/.config/protonmail/`. This should treat the directory as equivalent to `~/.cache` meaning it should create the directory in `$XDG_CACHE_HOME/protonmail`. This is inline with the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).

> `$XDG_CACHE_HOME` defines the base directory relative to which user-specific non-essential data files should be stored. If `$XDG_CACHE_HOME` is either not set or empty, a default equal to `$HOME/.cache` should be used. 

