### PR TITLE
Improve shebangs

### DIFF
--- a/internal/frontend/bridge-gui/bridge-gui/build.ps1
+++ b/internal/frontend/bridge-gui/bridge-gui/build.ps1
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Proton Mail Bridge. If not, see <https://www.gnu.org/licenses/>.
 
-#!/bin/bash
+#!/usr/bin/env bash
 
 $scriptpath = $MyInvocation.MyCommand.Path
 $scriptDir = Split-Path $scriptpath

--- a/internal/frontend/bridge-gui/bridge-gui/build.sh
+++ b/internal/frontend/bridge-gui/bridge-gui/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2022 Proton AG
 #
 # This file is part of Proton Mail Bridge.

--- a/utils/bridge_app_version.sh
+++ b/utils/bridge_app_version.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 # Copyright (c) 2022 Proton AG
 #

--- a/utils/changelog_linter.sh
+++ b/utils/changelog_linter.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright (c) 2022 Proton AG
 #

--- a/utils/credits.sh
+++ b/utils/credits.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright (c) 2022 Proton AG
 #

--- a/utils/dependency_license.sh
+++ b/utils/dependency_license.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright (c) 2022 Proton AG
 #

--- a/utils/githooks/pre-push
+++ b/utils/githooks/pre-push
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 # Copyright (c) 2022 Proton AG
 #

--- a/utils/gobinsec_update.sh
+++ b/utils/gobinsec_update.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright (c) 2022 Proton AG
 #

--- a/utils/missing_license.sh
+++ b/utils/missing_license.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright (c) 2022 Proton AG
 #

--- a/utils/rebranding.sh
+++ b/utils/rebranding.sh
@@ -1,4 +1,4 @@
-##!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright (c) 2022 Proton AG
 #

--- a/utils/release_notes.sh
+++ b/utils/release_notes.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright (c) 2022 Proton AG
 #

--- a/utils/remove_non_relative_links_darwin.sh
+++ b/utils/remove_non_relative_links_darwin.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright (c) 2022 Proton AG
 #


### PR DESCRIPTION
* Use /usr/bin/env to find interpreters instead of absolute paths
* Remove erroneous # from utils/rebranding.sh shebang