### PR TITLE
Fix typos found by codespell

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -44,7 +44,7 @@ Changelog [format](http://keepachangelog.com/en/1.0.0/)
 * GODT-2437: Silence harmless report to sentry.
 * GODT-2649: Clean up cache files after failed connector create (Gluon).
 * GODT-2638: Validate messages before import.
-* GODT-2646: Bump GPA and Gluon dependecy after CIRCL upgrade.
+* GODT-2646: Bump GPA and Gluon dependency after CIRCL upgrade.
 * GODT-2454: Only Send status update if transaction succeeded.
 * Test: fix flaky tests.
 * GODT-2628: Attempt to fix closed channel panic on logout.
@@ -104,7 +104,7 @@ Changelog [format](http://keepachangelog.com/en/1.0.0/)
 * GODT-2574: Fix label/unlabel of large amounts of messages.
 * GODT-2573: Handle invalid header fields in message.
 * GODT-2573: Crash on null update.
-* GODT-2407: Replace invalid email addresses with emtpy for new Drafts.
+* GODT-2407: Replace invalid email addresses with empty for new Drafts.
 
 ## [Bridge 3.1.3] Quebec
 
@@ -245,7 +245,7 @@ Changelog [format](http://keepachangelog.com/en/1.0.0/)
 * GODT-2429: Do not report context cancel to sentry.
 
 ### Fixed
-* GODT-2467: elide long email adresses in 'bad event' QML notification dialog.
+* GODT-2467: elide long email addresses in 'bad event' QML notification dialog.
 * GODT-2449: fix bug in Bridge-GUI's Exception::what().
 * GODT-2427: Parsing header issues.
 * GODT-2426: Fix crash on user delete.
@@ -262,7 +262,7 @@ Changelog [format](http://keepachangelog.com/en/1.0.0/)
 * GODT-2404: Handle unexpected EOF.
 * GODT-2400: Allow state updates to be applied if command fails.
 * GODT-2399: Fix immediate message deletion during updates.
-* GODT-2390: Missing changes from pervious commit.
+* GODT-2390: Missing changes from previous commit.
 * GODT-2390: Add reports for uncaught json and net.opErr.
 * GODT-2414: Multiple deletion bug in WriteControlledStore.
 
@@ -327,7 +327,7 @@ GODT-1804: Preserve MIME parameters when uploading attachments.
 * GODT-2223: Improve event handling.
 * GODT-2305: Detect missing gluon DB.
 * GODT-2291: Change gluon store default location from Cache to Data.
-* Other: Disable dialer test until badssl cert is bumbed.
+* Other: Disable dialer test until badssl cert is bumped.
 * GODT-2292: Updated BUILDS.md doc.
 * GODT-2258: suggest email as login when signing in via status window.
 * Other: Report corrupt and/or insecure vaults to sentry.
@@ -607,7 +607,7 @@ GODT-1804: Preserve MIME parameters when uploading attachments.
 ## [Bridge 2.4.6] Osney
 
 ### Changed
-* GODT-2019: When signing out and a single user is connecte* we do not go back to the welcome screen.
+* GODT-2019: When signing out and a single user is connected we do not go back to the welcome screen.
 * GODT-2071: Bridge-gui report error if an orphan bridge is detected.
 * GODT-2046: Bridge-gui log is included in optional archive sent with bug reports.
 * GODT-2039: Bridge monitors bridge-gui via its PID.
@@ -761,7 +761,7 @@ GODT-1804: Preserve MIME parameters when uploading attachments.
     * GODT-1260: Renaming.
     * GODT-1502: Rebranding: color and radius.
 * GODT-1549: Add notification when address list changes.
-* GODT-1560: Dependecy licenses update and link.
+* GODT-1560: Dependency licenses update and link.
 
 ### Changed
 * GODT-1543: Using one buffered event for off and on connection.
@@ -858,7 +858,7 @@ GODT-1537: Manual in-app update mechanism.
     * GODT-1338: GODT-1343 Help view buttons.
     * GODT-1340: Not crashing, user list updating in main thread.
     * GODT-1345: Adding panic handlers.
-    * GODT-1271: Fix Status margings.
+    * GODT-1271: Fix Status margins.
     * GODT-1320: Add loading property to each action within a notification.
     * GODT-1210: Add "free user" banner.
     * GODT-1314: Limit description field length within 150/800 bounds.
@@ -900,7 +900,7 @@ GODT-1537: Manual in-app update mechanism.
     * GODT-1381 Treat readonly folder as failure for cache on disk.
     * GODT-1431 Prevent watcher when not using disk on cache.
     * GODT-1381: Use in-memory cache in case local cache is unavailable.
-    * GODT-1356 GODT-1302: Cache on disk concurency and API retries.
+    * GODT-1356 GODT-1302: Cache on disk concurrency and API retries.
     * GODT-1332 Added tests for cache move functions.
     * GODT-1332: moved cache related functions to separate file.
     * GODT-1332 moving cache does not work on Windows.
@@ -1151,7 +1151,7 @@ GODT-1537: Manual in-app update mechanism.
 ### Fixed
 * GODT-1029 Fix tray icon not updating under certain conditions.
 * GODT-1062 Fix lost notification bar when window is closed.
-* GODT-1058 Install version after chaning channel right away only in case of downgrade.
+* GODT-1058 Install version after changing channel right away only in case of downgrade.
 * GODT-1073 Re-write autostart link on every start if turned on in preferences.
 * GODT-1055 Fix flaky empty trash test.
 
@@ -1241,7 +1241,7 @@ GODT-1537: Manual in-app update mechanism.
 * GODT-820 Added GUI notification on impossibility of update installation (both silent and manual).
 * GODT-870 Added GUI notification on error during silent update.
 * GODT-805 Added GUI notification on update available.
-* GODT-804 Added GUI notification on silent update installed (promt to restart).
+* GODT-804 Added GUI notification on silent update installed (prompt to restart).
 * GODT-275 Added option to disable autoupdates in settings (default autoupdate is enabled).
 * GODT-874 Added manual triggers to Updater module.
 * GODT-851 Added support of UID EXPUNGE.
@@ -1565,7 +1565,7 @@ CSB-331 Fix sending error due to mixed case in sender address.
 
 ### Changed
 * GODT-360 Detect charset embedded in html/xml.
-* GODT-354 Do not label/unlabel messsages from `All Mail` folder.
+* GODT-354 Do not label/unlabel messages from `All Mail` folder.
 * GODT-388 Support for both bridge and import/export credentials by package users.
 * GODT-387 Store factory to make store optional.
 * GODT-386 Renamed bridge to general users and keep bridge only for bridge stuff.
@@ -1730,13 +1730,13 @@ CSB-331 Fix sending error due to mixed case in sender address.
 * GODT-88 Run mbox sync in parallel when switch password mode (re-init not user).
 * GODT-95 Do not throw error when trying to create new mailbox in IMAP root.
 * GODT-75 Do not fail on unlabel inside delete.
-* #1095 always delete IMAP USER including wrong pasword.
+* #1095 always delete IMAP USER including wrong password.
 * Unique pmapi client userID (including #1098).
 * Using go.enmime@v0.6.1 snapshot.
 * Better detection of non-auth-error.
 * Reset `hasAuthChannel` during logout for proper login functionality (set up auth channel and unlock keys).
 * Allow `APPEND` messages without parsable email address in sender field.
-* #1060 avoid `Append` after internal message ID was found and message was copyed to mailbox using `MessageLabel`.
+* #1060 avoid `Append` after internal message ID was found and message was copied to mailbox using `MessageLabel`.
 * #1049 Basic usage of store in SMTP package to poll event loop during sending message.
 * #1050 pollNow waits for events to be processed.
 * #1047 Fix fetch of empty mailbox.
@@ -1862,7 +1862,7 @@ CSB-331 Fix sending error due to mixed case in sender address.
 * #903 added http.Client timeout to not hang out forever.
 * Closing body after checking internet connection.
 * Pedantic lint for bridgeUtils.
-* Selected events are buffered and emited again when frontend loop is ready.
+* Selected events are buffered and emitted again when frontend loop is ready.
 * #890 implemented 2FA endpoint (auth split).
 * #888 TLS Cert.
     * Error bar and modal with explanation in GUI.
@@ -1870,7 +1870,7 @@ CSB-331 Fix sending error due to mixed case in sender address.
     * Add pinning to bridge (only for live API builds).
 * #887 #883:
  * Wait before clearing data.
- * Configer which provides pmapi.ClientConfig and app directories.
+ * Configure which provides pmapi.ClientConfig and app directories.
 * #861 restart after clear data.
 * Panic handler for all goroutines.
 * CD for linux.
@@ -1918,7 +1918,7 @@ CSB-331 Fix sending error due to mixed case in sender address.
 * #882 unassign PMAPI client after logout and force to run garbage collector.
 * #880, #884, #885, #886 fix of informing user about outgoing non-encrypted e-mail.
 * #838 `Sirupsen` -> `sirupsen`.
-* #893 save panic report file everytime.
+* #893 save panic report file every time.
 * #880 fix of informing user about outgoing non-encrypted e-mail.
 * Fix aliases in split mode.
 * Fix decrypted data in log notification.
@@ -1992,7 +1992,7 @@ CSB-331 Fix sending error due to mixed case in sender address.
 
 ### Changed
 * Fix custom message format.
-* #802 acumulated long lines while parsing body structure.
+* #802 accumulated long lines while parsing body structure.
 * Process `AddressEvent` before `MessageEvent`.
 * #791 updated crypto: fix wrong signature format.
 * #793 fix returning size.
@@ -2014,7 +2014,7 @@ CSB-331 Fix sending error due to mixed case in sender address.
 
 ### Changed
 * #748 when charset missing assume utf8 and check the validity.
-* #750 before sync check that events are uptodate, if not poll events instead of sync.
+* #750 before sync check that events are up-to-date, if not poll events instead of sync.
 * Use pmapi with support of decrypted access token.
 * #750 Status is using DB status instead of API.
 * Format panic error as string instead of struct dump.
@@ -2031,7 +2031,7 @@ CSB-331 Fix sending error due to mixed case in sender address.
 * Full version of program visible on release notes.
 
 ### Changed
-* #720 only one concurent DB sync.
+* #720 only one concurrent DB sync.
 * #720 sync every 3 pages.
 * #512 extending list of charsets go-pm-mime!4.
 
@@ -2055,7 +2055,7 @@ CSB-331 Fix sending error due to mixed case in sender address.
 * Fix srp modulus issue with new `ProtonMail/crypto`.
 * Generate version files from main file.
 * Be able to set update set on build.
-* #597 check on start that certificat will be still valid after one month and generate new cert if not.
+* #597 check on start that certificate will be still valid after one month and generate new cert if not.
 * #597 extended certificate validity to 2 years.
 * Copyright 2019.
 * Exclude `protontech` repos from credits.
@@ -2074,7 +2074,7 @@ CSB-331 Fix sending error due to mixed case in sender address.
 * #592 internal references are added only when not present already.
 * #592 field `Date` changed to m.Time only when wrong format or missing `Date`.
 * #645 pmapi#26 `Message.Flags` instead of `IsEncrypted`, `Type`, `IsReplied`, `IsRepliedAll`, `IsForwarded`.
-* DB: do not allow to put Body or Attachements to db.
+* DB: do not allow to put Body or Attachments to db.
 * #574 SMTP: can now send more than one email.
 * #671 Verbosity levels: `debug` (only bridge), `debug-client` (bridge and client communication), `debug-server` (bridge, whole SMTP/IMAP communication).
 * #644 Return rfc.size 0 or correct size of fetched body (stored in DB).
@@ -2146,7 +2146,7 @@ CSB-331 Fix sending error due to mixed case in sender address.
 * Start with new versioning.
 
           1.1.0
-          | | `--- bug fix number (internal, irregular, beta relases)
+          | | `--- bug fix number (internal, irregular, beta releases)
           | `----- minor version (features, release once per month, live release, milestones)
           `------- major version (big changes, once per year, breaking changes, api force upgrade)
 
@@ -2212,7 +2212,7 @@ CSB-331 Fix sending error due to mixed case in sender address.
 * All `client.Do` errors are interpreted as connection issue.
 * Moved to internal gitlab.
 * Typo `frontend-qml`.
-* Better message for case when server is not reacheable.
+* Better message for case when server is not reachable.
 * Setting 1min timeout to IMAP connection.
 
 ### Changed
@@ -2244,12 +2244,12 @@ CSB-331 Fix sending error due to mixed case in sender address.
 * Keychain format and function refactor.
 * Create crash file on panic with full trace.
 * Clear old data only in main process (no double keychain typing).
-* Create label udpate API route.
+* Create label update API route.
 * Selectable text in release notes.
 
 ### Added
 * Support sending to external PGP recipients.
-* Return error codes: `0: Ok`, `2: Frontend crashed`, `3: Bridge already running`, `4: Uknown argument`, `42: Restart application`.
+* Return error codes: `0: Ok`, `2: Frontend crashed`, `3: Bridge already running`, `4: Unknown argument`, `42: Restart application`.
 
 ### Release notes
 * Support of encryption to external PGP recipients using contacts created on beta.protonmail.com (see https://protonmail.com/blog/pgp-vulnerability-efail/ to understand the vulnerabilities that may be associated with sending to other PGP clients).
@@ -2274,7 +2274,7 @@ CSB-331 Fix sending error due to mixed case in sender address.
     * Bug report window.
     * Checkbox and with label (only I/E).
     * Error dialog and Info tooltip (only I/E).
-    * Add user modal formating (colors, text).
+    * Add user modal formatting (colors, text).
     * Account view style.
     * Input box style (used in bug report).
     * Input field style (used in add account and change port).

--- a/doc/communication.md
+++ b/doc/communication.md
@@ -2,13 +2,13 @@
 
 ## First login and sync
 
-When user logs in to the bridge for the first time, immediatelly starts the first sync.
+When user logs in to the bridge for the first time, immediately starts the first sync.
 First sync downloads all headers of all e-mails and creates database to have proper UIDs
 and indexes for IMAP. See [database](database.md) for more information.
 
 By default, whenever it's possible, sync downloads only all e-mails maiblox which already
 have list of labels so we can construct all mailboxes (inbox, sent, trash, custom folders
-and lables) without need to download each e-mail headers many times.
+and labels) without need to download each e-mail headers many times.
 
 Note that we need to download also bodies to calculate size of the e-mail and set proper
 content type (clients uses content type for guess if e-mail contains attachment)--but only
@@ -22,7 +22,7 @@ client right after adding account.
 
 When account is added to client, client start the sync. This sync will ask Bridge app
 for all headers (done quickly) and then starts to download all bodies and attachment.
-Unfortunatelly for some e-mail more than once if the same e-mail is in more mailboxes
+Unfortunately for some e-mail more than once if the same e-mail is in more mailboxes
 (e.g. inbox and all mail)--there is no way to tell over IMAP it's the same message.
 
 After successful login of client to IMAP, Bridge starts event loop. That periodicly ask
@@ -37,7 +37,7 @@ sequenceDiagram
     Note right of B: Set up PM account<br/>by user
 
     loop First sync
-        B ->> S: Fetch body and attachements
+        B ->> S: Fetch body and attachments
         Note right of B: Build local database<br/>(e-mail UIDs)
     end
 
@@ -58,8 +58,8 @@ sequenceDiagram
         C ->> B: IMAP SELECT directory
         C ->> B: IMAP SEARCH e-mails UIDs
         C ->> B: IMAP FETCH of e-mail UID
-        B ->> S: Fetch body and attachements
-        Note right of B: Decrypt message<br/>and attachement
+        B ->> S: Fetch body and attachments
+        Note right of B: Decrypt message<br/>and attachment
         B ->> C: IMAP response
     end
 ```

--- a/doc/updates.md
+++ b/doc/updates.md
@@ -1,12 +1,12 @@
 # Update mechanism of Bridge
 
-There are mulitple options how to change version of application:
+There are multiple options how to change version of application:
 * Automatic in-app update
 * Manual in-app update
 * Manual install
 
 In-app update ends with restarting bridge into new version. Automatic in-app
-update is downloading, verifying and installing the new version immediatelly
+update is downloading, verifying and installing the new version immediately
 without user confirmation. For manual in-app update user needs to confirm first.
 Update is done from special update file published on website.
 
@@ -25,7 +25,7 @@ The bridge is installed and executed differently for given OS:
 
 * macOS app does not use launcher
     * No launcher, only one executable
-    * In-App udpate replaces the bridge files in installation path directly
+    * In-App update replaces the bridge files in installation path directly
 
 
 ```mermaid

--- a/internal/bridge/sync_unix_test.go
+++ b/internal/bridge/sync_unix_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Disabled due to flakyness.
+// Disabled due to flakiness.
 func _TestBridge_SyncExistsWithErrorWhenTooManyFilesAreOpen(t *testing.T) { //nolint:unused
 	var rlimitCurrent syscall.Rlimit
 

--- a/internal/frontend/bridge-gui/bridge-gui/QMLBackend.h
+++ b/internal/frontend/bridge-gui/bridge-gui/QMLBackend.h
@@ -46,7 +46,7 @@ public: // member functions.
     bool waitForEventStreamReaderToFinish(qint32 timeoutMs); ///< Wait for the event stream reader to finish.
     UserList const& users() const; ///< Return the list of users
 
-    // invokable methods can be called from QML. They generally return a value, which slots cannot do.
+    // invocable methods can be called from QML. They generally return a value, which slots cannot do.
     Q_INVOKABLE static QString buildYear(); ///< Return the application build year.
     Q_INVOKABLE QPoint getCursorPos() const; ///< Retrieve the cursor position.
     Q_INVOKABLE bool isPortFree(int port) const; ///< Check if a given network port is available.

--- a/internal/frontend/bridge-gui/bridge-gui/TrayIcon.cpp
+++ b/internal/frontend/bridge-gui/bridge-gui/TrayIcon.cpp
@@ -34,7 +34,7 @@ QColor const warnColor(255, 153, 0); ///< The warn state color.
 QColor const updateColor(35, 158, 206); ///< The warn state color.
 QColor const greyColor(112, 109, 107); ///< The grey color.
 qint64 const iconRefreshTimerIntervalMs = 1000; ///< The interval for the refresh timer when switching DPI / screen config, in milliseconds.
-qint64 const iconRefreshDurationSecs = 10; ///< The total number of seconds during wich we periodically refresh the icon after a DPI change.
+qint64 const iconRefreshDurationSecs = 10; ///< The total number of seconds during which we periodically refresh the icon after a DPI change.
 
 
 //****************************************************************************************************************************************************

--- a/internal/frontend/bridge-gui/bridge-gui/build.sh
+++ b/internal/frontend/bridge-gui/bridge-gui/build.sh
@@ -63,7 +63,7 @@ BRIDGE_BUILD_ENV= ${BRIDGE_BUILD_ENV:-"dev"}
 git submodule update --init --recursive ${VCPKG_ROOT}
 check_exit "Failed to initialize vcpkg as a submodule."
 
-echo submodule udpated
+echo submodule updated
 
 VCPKG_EXE="${VCPKG_ROOT}/vcpkg"
 VCPKG_BOOTSTRAP="${VCPKG_ROOT}/bootstrap-vcpkg.sh"

--- a/internal/frontend/bridge-gui/bridgepp/Doxyfile
+++ b/internal/frontend/bridge-gui/bridgepp/Doxyfile
@@ -101,7 +101,7 @@ CREATE_SUBDIRS         = YES
 # level increment doubles the number of directories, resulting in 4096
 # directories at level 8 which is the default and also the maximum value. The
 # sub-directories are organized in 2 levels, the first level always has a fixed
-# numer of 16 directories.
+# number of 16 directories.
 # Minimum value: 0, maximum value: 8, default value: 8.
 # This tag requires that the tag CREATE_SUBDIRS is set to YES.
 

--- a/internal/frontend/bridge-gui/bridgepp/bridgepp/FocusGRPC/FocusGRPCClient.cpp
+++ b/internal/frontend/bridge-gui/bridgepp/bridgepp/FocusGRPC/FocusGRPCClient.cpp
@@ -69,10 +69,10 @@ void FocusGRPCClient::removeServiceConfigFile(QString const &configDir) {
 
 
 //****************************************************************************************************************************************************
-/// \param[in] timeoutMs The timeout for the connexion.
+/// \param[in] timeoutMs The timeout for the connection.
 /// \param[in] port The gRPC server port.
 /// \param[out] outError if not null and the function returns false.
-/// \return true iff the connexion was successfully established.
+/// \return true iff the connection was successfully established.
 //****************************************************************************************************************************************************
 bool FocusGRPCClient::connectToServer(qint64 timeoutMs, quint16 port, QString *outError) {
     try {
@@ -88,7 +88,7 @@ bool FocusGRPCClient::connectToServer(qint64 timeoutMs, quint16 port, QString *o
         }
 
         if (channel_->GetState(true) != GRPC_CHANNEL_READY) {
-            throw Exception("Connexion check with focus service failed.");
+            throw Exception("Connection check with focus service failed.");
         }
 
         return true;

--- a/internal/frontend/bridge-gui/bridgepp/bridgepp/GRPC/GRPCClient.cpp
+++ b/internal/frontend/bridge-gui/bridgepp/bridgepp/GRPC/GRPCClient.cpp
@@ -58,7 +58,7 @@ void GRPCClient::removeServiceConfigFile(QString const &configDir) {
 
 //****************************************************************************************************************************************************
 /// \param[in] timeoutMs The timeout in milliseconds
-/// \param[in] serverProcess An optional server process to monitor. If the process it, no need and retry, as connexion cannot be established. Ignored if null.
+/// \param[in] serverProcess An optional server process to monitor. If the process it, no need and retry, as connection cannot be established. Ignored if null.
 /// \return The service config.
 //****************************************************************************************************************************************************
 GRPCConfig GRPCClient::waitAndRetrieveServiceConfig(QString const &configDir, qint64 timeoutMs, ProcessMonitor *serverProcess) {
@@ -114,7 +114,7 @@ void GRPCClient::setLog(Log *log) {
 
 
 //****************************************************************************************************************************************************
-/// \param[in] serverProcess An optional server process to monitor. If the process it, no need and retry, as connexion cannot be established. Ignored if null.
+/// \param[in] serverProcess An optional server process to monitor. If the process it, no need and retry, as connection cannot be established. Ignored if null.
 /// \return true iff the connection was successful.
 //****************************************************************************************************************************************************
 void GRPCClient::connectToServer(QString const &configDir, GRPCConfig const &config, ProcessMonitor *serverProcess) {
@@ -146,7 +146,7 @@ void GRPCClient::connectToServer(QString const &configDir, GRPCConfig const &con
         int i = 0;
         while (true) {
             if (serverProcess && serverProcess->getStatus().ended) {
-                throw Exception("Bridge application ended before gRPC connexion could be established.", QString(), __FUNCTION__,
+                throw Exception("Bridge application ended before gRPC connection could be established.", QString(), __FUNCTION__,
                     tailOfLatestBridgeLog());
             }
 

--- a/internal/frontend/grpc/service_methods.go
+++ b/internal/frontend/grpc/service_methods.go
@@ -461,7 +461,7 @@ func (s *Service) Login2FA(_ context.Context, login *LoginRequest) (*emptypb.Emp
 		defer async.HandlePanic(s.panicHandler)
 
 		if s.auth.UID == "" || s.authClient == nil {
-			s.log.Errorf("Login 2FA: authethication incomplete %s %p", s.auth.UID, s.authClient)
+			s.log.Errorf("Login 2FA: authentication incomplete %s %p", s.auth.UID, s.authClient)
 			_ = s.SendEvent(NewLoginError(LoginErrorType_TFA_ABORT, "Missing authentication, try again."))
 			s.loginClean()
 			return

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -34,11 +34,11 @@ import (
 const (
 	// MaxLogSize defines the maximum log size we should permit: 5 MB
 	//
-	// The Zendesk limit for an attachement is 50MB and this is what will
+	// The Zendesk limit for an attachment is 50MB and this is what will
 	// be allowed via the API. However, if that fails for some reason, the
 	// fallback is sending the report via email, which has a limit of 10mb
 	// total or 7MB per file. Since we can produce up to 6 logs, and we
-	// compress all the files (avarage compression - 80%), we need to have
+	// compress all the files (average compression - 80%), we need to have
 	// a limit of 30MB total before compression, hence 5MB per log file.
 	MaxLogSize = 5 * 1024 * 1024
 

--- a/internal/user/sync.go
+++ b/internal/user/sync.go
@@ -320,7 +320,7 @@ func (user *User) syncMessages(
 	case maxSyncMemory == 2*Gigabyte:
 		// Increasing the max download capacity has very little effect on sync speed. We could increase the download
 		// memory but the user would see less sync notifications. A smaller value here leads to more frequent
-		// updates. Additionally, most of ot sync time is spent in the message building.
+		// updates. Additionally, most of sync time is spent in the message building.
 		syncMaxDownloadRequestMem = MaxDownloadRequestMem
 		// Currently limited so that if a user has multiple accounts active it also doesn't cause excessive memory usage.
 		syncMaxMessageBuildingMem = MaxMessageBuildingMem

--- a/pkg/cpc/cpc.go
+++ b/pkg/cpc/cpc.go
@@ -24,7 +24,7 @@ import (
 
 var ErrInvalidReplyType = errors.New("reply type does not match")
 
-// Utilities to implement Chanel Procedure Calls. Similar in concept to RPC, but with between go-routines.
+// Utilities to implement Channel Procedure Calls. Similar in concept to RPC, but with between go-routines.
 
 // Request contains the data for a request as well as the means to reply to a request.
 type Request struct {

--- a/pkg/keychain/helper_darwin.go
+++ b/pkg/keychain/helper_darwin.go
@@ -115,7 +115,7 @@ func (h *macOSHelper) Get(secretURL string) (string, string, error) {
 
 	results, err := keychain.QueryItem(query)
 	if err != nil {
-		l.WithError(err).Error("Querry item failed")
+		l.WithError(err).Error("Query item failed")
 		return "", "", parseError(err)
 	}
 

--- a/pkg/mime/encoding.go
+++ b/pkg/mime/encoding.go
@@ -205,7 +205,7 @@ func EncodeHeader(s string) string {
 	return mime.QEncoding.Encode("utf-8", s)
 }
 
-// DecodeCharset decodes the orginal using content type parameters.
+// DecodeCharset decodes the original using content type parameters.
 // If the charset parameter is missing it checks that the content is valid utf8.
 // If it isn't, it checks if it's embedded in the html/xml.
 // If it isn't, it falls back to windows-1252.
@@ -240,7 +240,7 @@ func DecodeCharset(original []byte, contentType string) ([]byte, error) {
 		logrus.WithField("encoding", name).Warn("Determined encoding but was not certain")
 	}
 
-	// Reencode as UTF-8.
+	// Re-encode as UTF-8.
 	decoded, err := encoding.NewDecoder().Bytes(original)
 	if err != nil {
 		return original, errors.Wrap(err, "failed to decode as windows-1252")

--- a/pkg/mime/encoding_test.go
+++ b/pkg/mime/encoding_test.go
@@ -446,7 +446,7 @@ func TestEncodeReader(t *testing.T) {
 		}
 
 		if bytes.Equal(decoded, expected) {
-			// fmt.Println("Succesfull decoding of ", val.params, ":", string(decoded))
+			// fmt.Println("Successful decoding of ", val.params, ":", string(decoded))
 		} else {
 			t.Error("Wrong encoding of ", val.charset, ".Expected\n", expected, "\nbut have\n", decoded)
 		}

--- a/pkg/tar/tar.go
+++ b/pkg/tar/tar.go
@@ -28,7 +28,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// maxFileSize limit tre single file size after decopression is not larger than 1GB.
+// maxFileSize limit the single file size after decopression is not larger than 1GB.
 const maxFileSize = int64(1 * 1024 * 1024 * 1024) // 1 GB
 
 // ErrFileTooLarge returned when decompressed file is too large.

--- a/release-notes/bridge_early.md
+++ b/release-notes/bridge_early.md
@@ -178,7 +178,7 @@
 - Improved Sentry reporting
 
 ### Fixed
-- Ensure messageID is properly removed from DB when it is no logner present on the API
+- Ensure messageID is properly removed from DB when it is no longer present on the API
 
 
 ## v2.1.0
@@ -372,7 +372,7 @@ New local cache
 - Added IMAP requests to the logs for easier debugging 
 
 ### Fixed
-- NoGUI bulid
+- NoGUI buiid
 - Background of GUI welcome message
 - Incorrect total mailbox size displayed in Apple Mail
 

--- a/release-notes/bridge_stable.md
+++ b/release-notes/bridge_stable.md
@@ -89,7 +89,7 @@
 - Improved Sentry reporting
 
 ### Fixed
-- Ensure messageID is properly removed from DB when it is no logner present on the API
+- Ensure messageID is properly removed from DB when it is no longer present on the API
 
 
 ## v2.1.0
@@ -251,7 +251,7 @@ Other
 - Fixed GUI freeze while switching to early update channel
 - Fixed Bridge autostart
 - Improved signing of update packages
-- NoGUI bulid
+- NoGUI build
 - Background of GUI welcome message
 - Incorrect total mailbox size displayed in Apple Mail
 

--- a/utils/QTBUG-88600/README.txt
+++ b/utils/QTBUG-88600/README.txt
@@ -1,3 +1,3 @@
-This is version of libqcocoa obtained from original Qt 5.13.0 source available at https://github.com/qt/qtbase with patch from cocoa.patch applyed. 
+This is version of libqcocoa obtained from original Qt 5.13.0 source available at https://github.com/qt/qtbase with patch from cocoa.patch applied. 
 
 Please refer to https://bugreports.qt.io/browse/QTBUG-88600 for patch origin and https://doc.qt.io/qt-5/macos-building.html for instructions how to build Qt from source.

--- a/utils/changelog_linter.sh
+++ b/utils/changelog_linter.sh
@@ -31,7 +31,7 @@ echo "0">$ERROR_COUNT_FILE
 # -- Helper functions -- #
 ##########################
 
-# err print out a given error ($2) and line where it hapens ($1),
+# err print out a given error ($2) and line where it happens ($1),
 # also it increases count of errors.
 err () {
     echo "CHANGELOG-LINTER: $2 on the following line:"
@@ -92,7 +92,7 @@ check_change_types () {
 
     case "$1" in
         "### Added"|"### Changed"|"### Deprecated"|"### Removed"|"### Fixed"|"### Security") ;; # Standard keepachangelog.com compliant types.
-        "### Release notes"|"### Fixed bugs") ;;                                                # Bridge aditional in app release notes types.
+        "### Release notes"|"### Fixed bugs") ;;                                                # Bridge additional in app release notes types.
         "### Guiding Principles"|"### Types of changes") ;;                                     # Ignoring guide at the end of the changelog.
         *) err "$1" "Change type must be one of the Added, Changed, Deprecated, Removed, Fixed, Hoftix"
     esac 

--- a/utils/dependency_license.sh
+++ b/utils/dependency_license.sh
@@ -45,7 +45,7 @@ generate_dep_licenses(){
     grep -E $'^\t[^=>]*$'    $src  | sed -r 's/\t([^ ]*) v.*/\1/g'         > "$tmpDepLicenses"
     grep -E $'^\t.*=>.*v.*$' $src  | sed -r 's/^.*=> ([^ ]*)( v.*)?/\1/g' >> "$tmpDepLicenses"
 
-    # Replace each line with formated link
+    # Replace each line with formatted link
     sed  -i -r '/^github.com\/therecipe\/qt\/internal\/binding\/files\/docs\//d;' "$tmpDepLicenses"
     sed -i -r 's|^(.*)/([[:alnum:]-]+)/(v[[:digit:]]+)$|* [\2](https://\1/\2/\3)|g' "$tmpDepLicenses"
     sed -i -r 's|^(.*)/([[:alnum:]-]+)$|* [\2](https://\1/\2)|g' "$tmpDepLicenses"

--- a/utils/remove_non_relative_links_darwin.sh
+++ b/utils/remove_non_relative_links_darwin.sh
@@ -20,10 +20,10 @@
 # The Qt libs are dynamically loaded with rules like: `@rpath/QtGui.framework/Versions/5/QtGui`
 # @rpath instructs the dynamic linker to search a list of paths in order to locate the framework
 # The rules can be listed using `otool -l "${path_to_binary}"`
-# The building process of therecipe/qt or qmake leaves the rules with additinal unwanted paths
+# The building process of therecipe/qt or qmake leaves the rules with additional unwanted paths
 #   + absolute path to build directory
 #   + dummy replacement `/break_the_rpath`
-# We need to manually remove those and add the path relative to exectuable: `@executable_path/../Frameworks`
+# We need to manually remove those and add the path relative to executable: `@executable_path/../Frameworks`
 
 path_to_binary=$1
 


### PR DESCRIPTION
I have a separate PR commit for `Changelog.md` as some projects prefer not modifying the changeleog. I can either revert that commit or squash into a single commit, at your convenience.