### PR TITLE
Dont wipe vault on decryption errors

### DIFF
--- a/internal/app/vault.go
+++ b/internal/app/vault.go
@@ -37,7 +37,7 @@ func WithVault(locations *locations.Locations, keychains *keychain.List, panicHa
 	// Create the encVault.
 	encVault, insecure, corrupt, err := newVault(locations, keychains, panicHandler)
 	if err != nil {
-		return fmt.Errorf("could not create vault: %w", err)
+		return fmt.Errorf("could not load/create vault: %w", err)
 	}
 
 	logrus.WithFields(logrus.Fields{
@@ -87,7 +87,7 @@ func newVault(locations *locations.Locations, keychains *keychain.List, panicHan
 
 	vault, corrupt, err := vault.New(vaultDir, gluonCacheDir, vaultKey, panicHandler)
 	if err != nil {
-		return nil, false, corrupt, fmt.Errorf("could not create vault: %w", err)
+		return nil, false, corrupt, err
 	}
 
 	return vault, insecure, corrupt, nil

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -360,6 +360,10 @@ func newVault(path, gluonDir string, gcm cipher.AEAD) (*Vault, error, error) {
 	var corrupt error
 
 	if err := unmarshalFile(gcm, enc, new(Data)); err != nil {
+		if errors.Is(err, ErrDecryptFailed) {
+			return nil, nil, err
+		}
+
 		corrupt = err
 	}
 

--- a/internal/vault/vault_test.go
+++ b/internal/vault/vault_test.go
@@ -28,44 +28,50 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestVault_DecryptFailed(t *testing.T) {
+	vaultDir, gluonDir := t.TempDir(), t.TempDir()
+
+	{
+		// Create
+		_, corrupt, err := vault.New(vaultDir, gluonDir, []byte("my secret key"), async.NoopPanicHandler{})
+		require.NoError(t, err)
+		require.NoError(t, corrupt)
+	}
+
+	{
+		// Load
+		_, corrupt, err := vault.New(vaultDir, gluonDir, []byte("my secret key"), async.NoopPanicHandler{})
+		require.NoError(t, err)
+		require.NoError(t, corrupt)
+	}
+
+	{
+		// Load with bad key
+		_, corrupt, err := vault.New(vaultDir, gluonDir, []byte("bad key"), async.NoopPanicHandler{})
+		require.ErrorIs(t, err, vault.ErrDecryptFailed)
+		require.NoError(t, corrupt)
+	}
+}
+
 func TestVault_Corrupt(t *testing.T) {
 	vaultDir, gluonDir := t.TempDir(), t.TempDir()
 
 	{
+		// Create
 		_, corrupt, err := vault.New(vaultDir, gluonDir, []byte("my secret key"), async.NoopPanicHandler{})
 		require.NoError(t, err)
 		require.NoError(t, corrupt)
 	}
 
 	{
+		// Load
 		_, corrupt, err := vault.New(vaultDir, gluonDir, []byte("my secret key"), async.NoopPanicHandler{})
 		require.NoError(t, err)
 		require.NoError(t, corrupt)
 	}
 
 	{
-		_, corrupt, err := vault.New(vaultDir, gluonDir, []byte("bad key"), async.NoopPanicHandler{})
-		require.NoError(t, err)
-		require.ErrorIs(t, corrupt, vault.ErrDecryptFailed)
-	}
-}
-
-func TestVault_Corrupt_JunkData(t *testing.T) {
-	vaultDir, gluonDir := t.TempDir(), t.TempDir()
-
-	{
-		_, corrupt, err := vault.New(vaultDir, gluonDir, []byte("my secret key"), async.NoopPanicHandler{})
-		require.NoError(t, err)
-		require.NoError(t, corrupt)
-	}
-
-	{
-		_, corrupt, err := vault.New(vaultDir, gluonDir, []byte("my secret key"), async.NoopPanicHandler{})
-		require.NoError(t, err)
-		require.NoError(t, corrupt)
-	}
-
-	{
+		// Load with junk data
 		f, err := os.OpenFile(filepath.Join(vaultDir, "vault.enc"), os.O_WRONLY, 0o600)
 		require.NoError(t, err)
 		defer f.Close() //nolint:errcheck


### PR DESCRIPTION
Fixes #470.

Previously, encryption errors from `unmarshalFile` were grouped together with vault load errors as "corrupt vault" errors, and https://github.com/kira-bruneau/proton-bridge/blob/2fd0985a523784ec412de68ec5bec5bf4309e485/internal/vault/vault.go#L370-L377 would reset the vault any time a vault was found to be "corrupt".

This PR just checks if the resulting error is an encryption error first, and if it is, wires it up like any other I/O error.