### PR TITLE
Fix qt crash

### DIFF
--- a/internal/frontend/bridge-gui/bridge-gui/qml/Banner.qml
+++ b/internal/frontend/bridge-gui/bridge-gui/qml/Banner.qml
@@ -28,7 +28,7 @@ Popup {
     implicitWidth: 600 // contentLayout.implicitWidth + contentLayout.anchors.leftMargin + contentLayout.anchors.rightMargin
     leftMargin: (mainWindow.width - root.implicitWidth) / 2
     modal: false
-    popupType: ApplicationWindow.PopupType.Banner
+    popupPrio: ApplicationWindow.PopupPriority.Banner
     shouldShow: notification ? (notification.active && !notification.dismissed) : false
     topMargin: 37
 

--- a/internal/frontend/bridge-gui/bridge-gui/qml/BugReport/QuestionItem.qml
+++ b/internal/frontend/bridge-gui/bridge-gui/qml/BugReport/QuestionItem.qml
@@ -13,6 +13,7 @@
 import QtQuick
 import QtQuick.Layouts
 import QtQuick.Controls
+import QtQuick.Controls.impl
 import Proton
 
 Item {

--- a/internal/frontend/bridge-gui/bridge-gui/qml/Proton/ApplicationWindow.qml
+++ b/internal/frontend/bridge-gui/bridge-gui/qml/Proton/ApplicationWindow.qml
@@ -21,7 +21,7 @@ T.ApplicationWindow {
     id: root
 
     // popup priority based on types
-    enum PopupType {
+    enum PopupPriority {
         Banner,
         Dialog
     }
@@ -78,10 +78,10 @@ T.ApplicationWindow {
                 topmost = obj;
                 break;
             }
-            if (topmost && (topmost.popupType > obj.popupType)) {
+            if (topmost && (topmost.popupPrio > obj.popupPrio)) {
                 continue;
             }
-            if (topmost && (topmost.popupType === obj.popupType) && (topmost.occurred > obj.occurred)) {
+            if (topmost && (topmost.popupPrio === obj.popupPrio) && (topmost.occurred > obj.occurred)) {
                 continue;
             }
             topmost = obj;

--- a/internal/frontend/bridge-gui/bridge-gui/qml/Proton/Dialog.qml
+++ b/internal/frontend/bridge-gui/bridge-gui/qml/Proton/Dialog.qml
@@ -21,7 +21,7 @@ T.Dialog {
 
     property ColorScheme colorScheme
     readonly property var occurred: shouldShow ? new Date() : undefined
-    readonly property int popupType: ApplicationWindow.PopupType.Dialog
+    readonly property int popupPrio: ApplicationWindow.PopupPriority.Dialog
     property bool shouldShow: false
 
     function close() {

--- a/internal/frontend/bridge-gui/bridge-gui/qml/Proton/InfoTooltip.qml
+++ b/internal/frontend/bridge-gui/bridge-gui/qml/Proton/InfoTooltip.qml
@@ -16,6 +16,7 @@
 // along with Proton Mail Bridge. If not, see <https://www.gnu.org/licenses/>.
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Controls.impl
 import QtQuick.Layouts
 
 ColorImage {

--- a/internal/frontend/bridge-gui/bridge-gui/qml/Proton/LinkLabel.qml
+++ b/internal/frontend/bridge-gui/bridge-gui/qml/Proton/LinkLabel.qml
@@ -12,6 +12,7 @@
 // along with Proton Mail Bridge. If not, see <https://www.gnu.org/licenses/>.
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Controls.impl
 import QtQuick.Layouts
 
 RowLayout {

--- a/internal/frontend/bridge-gui/bridge-gui/qml/Proton/Popup.qml
+++ b/internal/frontend/bridge-gui/bridge-gui/qml/Proton/Popup.qml
@@ -21,7 +21,7 @@ T.Popup {
 
     property ColorScheme colorScheme
     readonly property var occurred: shouldShow ? new Date() : undefined
-    property int popupType: ApplicationWindow.PopupType.Banner
+    property int popupPrio: ApplicationWindow.PopupPriority.Banner
     property bool shouldShow: false
 
     function close() {

--- a/internal/frontend/bridge-gui/bridge-gui/qml/SetupWizard/ClientConfigCertInstall.qml
+++ b/internal/frontend/bridge-gui/bridge-gui/qml/SetupWizard/ClientConfigCertInstall.qml
@@ -15,6 +15,7 @@ import QtQml
 import QtQuick
 import QtQuick.Layouts
 import QtQuick.Controls
+import QtQuick.Controls.impl
 
 Item {
     id: root

--- a/internal/frontend/bridge-gui/bridge-gui/qml/SetupWizard/ClientConfigParameters.qml
+++ b/internal/frontend/bridge-gui/bridge-gui/qml/SetupWizard/ClientConfigParameters.qml
@@ -14,6 +14,7 @@ import QtQml
 import QtQuick
 import QtQuick.Layouts
 import QtQuick.Controls
+import QtQuick.Controls.impl
 import ".."
 
 Rectangle {

--- a/internal/frontend/bridge-gui/bridge-gui/qml/SetupWizard/ClientListItem.qml
+++ b/internal/frontend/bridge-gui/bridge-gui/qml/SetupWizard/ClientListItem.qml
@@ -14,6 +14,7 @@ import QtQml
 import QtQuick
 import QtQuick.Layouts
 import QtQuick.Controls
+import QtQuick.Controls.impl
 
 Rectangle {
     id: root

--- a/internal/frontend/bridge-gui/bridge-gui/qml/SetupWizard/Login.qml
+++ b/internal/frontend/bridge-gui/bridge-gui/qml/SetupWizard/Login.qml
@@ -14,6 +14,7 @@ import QtQml
 import QtQuick
 import QtQuick.Layouts
 import QtQuick.Controls
+import QtQuick.Controls.impl
 
 FocusScope {
     id: root


### PR DESCRIPTION
This PR fixes #500 by:
- adding the import that defines `ColorImage` (an [undocumented](https://www.google.com/search?q="ColorImage"+site%3Ahttps%3A%2F%2Fdoc.qt.io%2F) QtQuick [internal](https://github.com/qt/qtdeclarative/blob/a4a90222aee5db576963ac641d7bb8203e5b1b84/src/quickcontrolsimpl/qquickcolorimage.cpp)) to the files that use it. The better fix would be to use a documented way of displaying images, but this is the simplest fix.
- Renames `popupType` to `popupPrio` as it is used for priority of popups, and because [`popupType` is a (final) property of QtQuick popups](https://doc.qt.io/qt-6/qml-qtquick-controls-popup.html#popup-type) since 6.8

Note that:
- Fixes are trivial
- Any platforms running Qt 6.8 are affected, so not Arch-specific as claimed in #500 (neither OpenSUSE-specific, Ubuntu non-LTS, Fedora 41, Fedora Rawhide, etc. etc. -- all up-to-date platforms are affected by the bug, the others will be in time when updating Qt)
- Qt 6.8 is marked as LTS so there is even more value in fixing this early on
- Seen the dismissive answers on #500 😢, I share this more for package maintainers and self-builders than hoping it will get merged. Feel free to use these patches until upstream provides their own fixes.