### PR TITLE
quoted-printable: No-op if Content-Transfer-Encoding header is already set

### DIFF
--- a/pkg/message/build.go
+++ b/pkg/message/build.go
@@ -491,8 +491,10 @@ func getTextPartHeader(hdr message.Header, body []byte, mimeType rfc822.MIMEType
 
 	hdr.SetContentType(string(mimeType), params)
 
-	// Use quoted-printable for all text/... parts
-	hdr.Set("Content-Transfer-Encoding", "quoted-printable")
+	// Use quoted-printable for all text/... parts UNLESS header is already set
+	if !hdr.Has("Content-Transfer-Encoding") {
+		hdr.Set("Content-Transfer-Encoding", "quoted-printable")
+	}
 
 	return hdr
 }

--- a/pkg/message/parser/parser.go
+++ b/pkg/message/parser/parser.go
@@ -109,7 +109,9 @@ func (p *Parser) AttachEmptyTextPartIfNoneExists() bool {
 	h := message.Header{}
 
 	h.Set("Content-Type", "text/plain;charset=utf8")
-	h.Set("Content-Transfer-Encoding", "quoted-printable")
+	if !h.Has("Content-Transfer-Encoding") {
+		h.Set("Content-Transfer-Encoding", "quoted-printable")
+	}
 
 	p.Root().AddChild(&Part{
 		Header: h,


### PR DESCRIPTION
This should allow git send-email to apply the transfer encoding desired when using the bridge.

(I was not able to compile this change on old version of Debian to test because my Go is out of date)