### PR TITLE
Allows the bridge to be in a separate server not just localhost

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 godog.test
 debug.test
 coverage.html
+coverage/
 gobinsec-cache*.yml
 
 # Run files
@@ -35,6 +36,7 @@ vendor-cache
 cmd/Desktop-Bridge/deploy
 cmd/Import-Export/deploy
 proton-bridge
+/bridge
 cmd/Desktop-Bridge/*.exe
 cmd/launcher/*.exe
 bin/
@@ -49,3 +51,13 @@ _doc/
 # gRPC auto-generated C++ source files
 *.pb.cc
 *.pb.h
+
+# Local certificates (never commit)
+*.pem
+/certs/
+
+# Local service script
+bridge_service.sh
+
+# System research/audit docs
+research/

--- a/internal/bridge/debug.go
+++ b/internal/bridge/debug.go
@@ -95,7 +95,7 @@ func (bridge *Bridge) CheckClientState(ctx context.Context, checkFlags bool, pro
 			return result, err
 		}
 
-		addr := fmt.Sprintf("127.0.0.1:%v", bridge.GetIMAPPort())
+		addr := fmt.Sprintf("0.0.0.0:%v", bridge.GetIMAPPort())
 
 		for account, mboxMap := range state {
 			if progressCB != nil {

--- a/internal/certs/tls.go
+++ b/internal/certs/tls.go
@@ -49,13 +49,13 @@ func NewTLSTemplate() (*x509.Certificate, error) {
 			Country:            []string{"CH"},
 			Organization:       []string{"Proton AG"},
 			OrganizationalUnit: []string{"Proton Mail"},
-			CommonName:         "127.0.0.1",
+			CommonName:         "0.0.0.0",
 		},
 		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
 		BasicConstraintsValid: true,
 		IsCA:                  true,
-		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1")},
+		IPAddresses:           []net.IP{net.ParseIP("0.0.0.0")},
 		NotBefore:             time.Now(),
 		NotAfter:              time.Now().Add(20 * 365 * 24 * time.Hour),
 	}, nil
@@ -110,7 +110,7 @@ func GetConfig(certPEM, keyPEM []byte) (*tls.Config, error) {
 	//nolint:gosec  // We need to support older TLS versions for AppleMail and Outlook
 	return &tls.Config{
 		Certificates: []tls.Certificate{c},
-		ServerName:   "127.0.0.1",
+		ServerName:   "0.0.0.0",
 		ClientAuth:   tls.VerifyClientCertIfGiven,
 		RootCAs:      caCertPool,
 		ClientCAs:    caCertPool,

--- a/internal/clientconfig/applemail_test.go
+++ b/internal/clientconfig/applemail_test.go
@@ -33,6 +33,6 @@ func TestEscapeXMLString(t *testing.T) {
 func _TestInstallCert(t *testing.T) { //nolint:unused
 	require.NoError(
 		t,
-		(&AppleMail{}).Configure(`127.0.0.1`, 1143, 1025, true, false, `user&>>`, `<<abc&&'"def>>`, `user&a`, []byte(`ir8R9vhdNXyB7isWzhyEkQ`)),
+		(&AppleMail{}).Configure(`0.0.0.0`, 1143, 1025, true, false, `user&>>`, `<<abc&&'"def>>`, `user&a`, []byte(`ir8R9vhdNXyB7isWzhyEkQ`)),
 	)
 }

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -68,7 +68,7 @@ const (
 	KeyChainName = "bridge-v3"
 
 	// Host is the hostname of the bridge server.
-	Host = "127.0.0.1"
+	Host = "0.0.0.0"
 )
 
 // nolint:goconst

--- a/internal/focus/service.go
+++ b/internal/focus/service.go
@@ -34,7 +34,7 @@ import (
 )
 
 const (
-	Host                 = "127.0.0.1"
+	Host                 = "0.0.0.0"
 	serverConfigFileName = "grpcFocusServerConfig.json"
 )
 

--- a/internal/frontend/bridge-gui/bridge-gui-tester/GRPCServerWorker.cpp
+++ b/internal/frontend/bridge-gui/bridge-gui-tester/GRPCServerWorker.cpp
@@ -67,7 +67,7 @@ void GRPCServerWorker::run() {
             builder.AddListeningPort(QString("unix://%1").arg(fileSocketPath).toStdString(), credentials);
             config.fileSocketPath = fileSocketPath;
         } else {
-            builder.AddListeningPort("127.0.0.1:0", credentials, &port);
+            builder.AddListeningPort("0.0.0.0:0", credentials, &port);
         }
 
         builder.RegisterService(&app().grpc());

--- a/internal/frontend/bridge-gui/bridge-gui/main.cpp
+++ b/internal/frontend/bridge-gui/bridge-gui/main.cpp
@@ -152,7 +152,7 @@ QUrl getApiUrl() {
     QUrl url;
     // use default url.
     url.setScheme("http");
-    url.setHost("127.0.0.1");
+    url.setHost("0.0.0.0");
     url.setPort(1042);
 
     // override with what can be found in the prefs.json file.

--- a/internal/frontend/bridge-gui/bridgepp/bridgepp/FocusGRPC/FocusGRPCClient.cpp
+++ b/internal/frontend/bridge-gui/bridgepp/bridgepp/FocusGRPC/FocusGRPCClient.cpp
@@ -29,7 +29,7 @@ namespace {
 
 
 Empty empty; ///< Empty protobuf message, re-used across calls.
-QString const hostname = "127.0.0.1"; ///< The hostname of the focus service.
+QString const hostname = "0.0.0.0"; ///< The hostname of the focus service.
 
 
 }

--- a/internal/frontend/bridge-gui/bridgepp/bridgepp/GRPC/GRPCClient.cpp
+++ b/internal/frontend/bridge-gui/bridgepp/bridgepp/GRPC/GRPCClient.cpp
@@ -127,9 +127,9 @@ void GRPCClient::connectToServer(QString const &sessionID, QString const &config
         grpc::ChannelArguments chanArgs;
         if (useFileSocketForGRPC()) {
             address = QString("unix://" + config.fileSocketPath);
-            chanArgs.SetSslTargetNameOverride("127.0.0.1"); // for file socket, we skip name verification to avoid a confusion localhost/127.0.0.1
+            chanArgs.SetSslTargetNameOverride("0.0.0.0"); // for file socket, we skip name verification to avoid a confusion localhost/127.0.0.1
         } else {
-            address = QString("127.0.0.1:%1").arg(config.port);
+            address = QString("0.0.0.0:%1").arg(config.port);
         }
 
         SslCredentialsOptions opts;

--- a/internal/frontend/grpc/service.go
+++ b/internal/frontend/grpc/service.go
@@ -141,7 +141,7 @@ func NewService(
 		}
 	} else {
 		var err error
-		listener, err = net.Listen("tcp", "127.0.0.1:0") // Port should be provided by the OS.
+		listener, err = net.Listen("tcp", "0.0.0.0:0") // Port should be provided by the OS.
 		if err != nil {
 			logrus.WithError(err).Panic("Could not create gRPC listener")
 		}

--- a/utils/port-blocker/port-blocker.go
+++ b/utils/port-blocker/port-blocker.go
@@ -67,7 +67,7 @@ func runBlocker(startPort, endPort int) {
 	}
 
 	for port := startPort; port <= endPort; port++ {
-		listener, err := net.Listen("tcp", "127.0.0.1:"+strconv.Itoa(port))
+		listener, err := net.Listen("tcp", "0.0.0.0:"+strconv.Itoa(port))
 		if err != nil {
 			fmt.Printf("Port %v is already blocked. Skipping.\n", port)
 		} else {

--- a/utils/smtp-send/main.go
+++ b/utils/smtp-send/main.go
@@ -29,7 +29,7 @@ import (
 )
 
 var (
-	serverURL    = flag.String("server", "127.0.0.1:1025", "SMTP server address:port")
+	serverURL    = flag.String("server", "0.0.0.0:1025", "SMTP server address:port")
 	userName     = flag.String("user-name", "user", "SMTP user name")
 	userPassword = flag.String("user-pwd", "password", "SMTP user password")
 	toAddr       = flag.String("toAddr", "", "Address toAddr whom toAddr send the message")


### PR DESCRIPTION
> [!CAUTION]
> This is not a recommended change nor use

For very few cases and advanced users or devs, this changes the hard-coded `127.0.0.1` IP from multiple parts exposing the bridge to the whole network allowing connections from anywhere by changing the hard-coded IP to `0.0.0.0`. 

**Do not use**. **Do not merge.** It's just a reference for anyone who may need it for advanced or special cases. 

Then build it with:
```bash
$ make build-nogui
```